### PR TITLE
chore: improve forward compatibility

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -37,6 +37,8 @@ dataSources:
           kind: cosmos/TransactionHandler
         - handler: handleMessage
           kind: cosmos/MessageHandler
+        - handler: handleEvent
+          kind: cosmos/EventHandler
         - handler: handleGovProposalVote
           kind: cosmos/MessageHandler
           filter:

--- a/project.yaml
+++ b/project.yaml
@@ -19,7 +19,7 @@ network:
   # You must connect to an archive (non-pruned) node
   endpoint: https://rpc-fetchhub.fetch.ai
   # Using a dictionary can massively improve indexing speed
-#  dictionary: https://api.subquery.network/sq/subquery/cosmos-juno-dictionary
+  dictionary: https://api.subquery.network/sq/subquery/cosmos-fetch-ai-dictionary
 
 dataSources:
   - kind: cosmos/Runtime

--- a/project.yaml
+++ b/project.yaml
@@ -35,6 +35,8 @@ dataSources:
           kind: cosmos/BlockHandler
         - handler: handleTransaction
           kind: cosmos/TransactionHandler
+        - handler: handleMessage
+          kind: cosmos/MessageHandler
         - handler: handleGovProposalVote
           kind: cosmos/MessageHandler
           filter:

--- a/project.yaml
+++ b/project.yaml
@@ -45,6 +45,10 @@ dataSources:
           kind: cosmos/MessageHandler
           filter:
             type: "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
+        - handler: handleExecuteContractMessage
+          kind: cosmos/MessageHandler
+          filter:
+            type: "/cosmwasm.wasm.v1.MsgExecuteContract"
         - handler: handleLegacyBridgeSwap
           kind: cosmos/MessageHandler
           filter:

--- a/project.yaml
+++ b/project.yaml
@@ -16,8 +16,7 @@ schema:
 
 network:
   chainId: fetchhub-4
-  # You must connect to an archive (non-pruned) node
-  endpoint: https://rpc-fetchhub.fetch.ai
+  endpoint: https://rpc-fetchhub.fetch.ai:443
   # Using a dictionary can massively improve indexing speed
   dictionary: https://api.subquery.network/sq/subquery/cosmos-fetch-ai-dictionary
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -13,8 +13,8 @@ enum TxStatus {
 
 type Block @entity {
   id: ID! # The block header hash
-  chainId: String!
-  height: BigInt!
+  chainId: String! @index
+  height: BigInt! @index
   timestamp: String!
 }
 
@@ -27,7 +27,7 @@ type Transaction @entity {
   memo: String
   status: TxStatus!
   log: String!
-  timeoutHeight: BigInt
+  timeoutHeight: BigInt @index
 }
 
 type Message @entity {
@@ -47,8 +47,8 @@ type Event @entity {
 
 type ExecuteContractMessage @entity {
   id: ID!
-  sender: String!
-  contract: String!
+  sender: String! @index
+  contract: String! @index
   funds: String!
   message: Message!
   transaction: Transaction!
@@ -57,8 +57,8 @@ type ExecuteContractMessage @entity {
 
 type GovProposalVote @entity {
   id: ID!
-  proposalId: String!
-  voterAddress: String!
+  proposalId: String! @index
+  voterAddress: String! @index
   option: GovProposalVoteOption!
   message: Message!
   transaction: Transaction!

--- a/schema.graphql
+++ b/schema.graphql
@@ -11,6 +11,11 @@ enum TxStatus {
   Error
 }
 
+type EventAttribute @jsonField {
+  key: String!
+  value: String!
+}
+
 type Block @entity {
   id: ID! # The block header hash
   chainId: String! @index
@@ -43,7 +48,8 @@ type Message @entity {
 
 type Event @entity {
   id: ID!
-  json: String!
+  type: String! @index
+  attributes: [EventAttribute]!
   log: String!
   transaction: Transaction!
   block: Block!

--- a/schema.graphql
+++ b/schema.graphql
@@ -16,6 +16,9 @@ type Block @entity {
   chainId: String! @index
   height: BigInt! @index
   timestamp: String!
+  transactions: [Transaction] @derivedFrom(field: "block")
+  messages: [Message] @derivedFrom(field: "block")
+  events: [Event] @derivedFrom(field: "block")
 }
 
 type Transaction @entity {
@@ -28,6 +31,7 @@ type Transaction @entity {
   status: TxStatus!
   log: String!
   timeoutHeight: BigInt @index
+  messages: [Message] @derivedFrom(field: "transaction")
 }
 
 type Message @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -41,6 +41,7 @@ type Transaction @entity {
 
 type Message @entity {
   id: ID!
+  typeUrl: String! @index
   json: String!
   transaction: Transaction!
   block: Block!

--- a/schema.graphql
+++ b/schema.graphql
@@ -18,14 +18,6 @@ type Block @entity {
   timestamp: String!
 }
 
-type ExecuteEvent @entity {
-  id: ID!
-  json: String!
-  log: String!
-  transaction: Transaction!
-  block: Block!
-}
-
 type Transaction @entity {
   id: ID!
   block: Block!
@@ -41,6 +33,14 @@ type Transaction @entity {
 type Message @entity {
   id: ID!
   json: String!
+  transaction: Transaction!
+  block: Block!
+}
+
+type Event @entity {
+  id: ID!
+  json: String!
+  log: String!
   transaction: Transaction!
   block: Block!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,34 +1,3 @@
-type Block @entity {
-  id: ID! # The block hash
-  height: BigInt!
-}
-
-type ExecuteEvent @entity {
-  id: ID!
-  blockHeight: BigInt!
-  txHash: String!
-  contractAddress: String!
-}
-
-type Transaction @entity {
-  id: ID!
-  blockHeight: BigInt!
-  timestamp: String!
-  status: String
-  gasUsed: BigInt
-  gasWanted: BigInt
-#  fee: BigInt
-#  memo: String
-}
-
-type Message @entity {
-  id: ID!
-  blockHeight: BigInt!
-  txHash: String!
-  sender: String!
-  contract: String!
-}
-
 enum GovProposalVoteOption {
   EMPTY,
   YES,
@@ -37,22 +6,79 @@ enum GovProposalVoteOption {
   NO_WITH_VETO,
 }
 
+enum TxStatus {
+  Success
+  Error
+}
+
+type Block @entity {
+  id: ID! # The block header hash
+  chainId: String!
+  height: BigInt!
+  timestamp: String!
+}
+
+type ExecuteEvent @entity {
+  id: ID!
+  json: String!
+  log: String!
+  transaction: Transaction!
+  block: Block!
+}
+
+type Transaction @entity {
+  id: ID!
+  block: Block!
+  gasUsed: BigInt!
+  gasWanted: BigInt!
+  fees: String!
+  memo: String
+  status: TxStatus!
+  log: String!
+  timeoutHeight: BigInt
+}
+
+type Message @entity {
+  id: ID!
+  json: String!
+  transaction: Transaction!
+  block: Block!
+}
+
+type ExecuteContractMessage @entity {
+  id: ID!
+  sender: String!
+  contract: String!
+  funds: String!
+  message: Message!
+  transaction: Transaction!
+  block: Block!
+}
+
 type GovProposalVote @entity {
   id: ID!
   proposalId: String!
   voterAddress: String!
   option: GovProposalVoteOption!
-#  TODO:
-#  weightedOptions: []
+  message: Message!
+  transaction: Transaction!
+  block: Block!
+  #  TODO:
+  #  weightedOptions: []
 }
 
 type DistDelegatorClaim @entity {
   id: ID!
   delegatorAddress: String!
   validatorAddress: String!
+  message: Message!
+  transaction: Transaction!
+  block: Block!
+  # TODO:
   #  validator: Validator!
   # TODO: introduced in cosmos-sdk (baseline) v0.46
   #  amount: BigInt!
+  #  denom: String!
 }
 
 type LegacyBridgeSwap @entity {
@@ -60,4 +86,7 @@ type LegacyBridgeSwap @entity {
   destination: String!
   amount: BigInt!
   denom: String!
+  message: Message!
+  transaction: Transaction!
+  block: Block!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -59,4 +59,5 @@ type LegacyBridgeSwap @entity {
   id: ID! # id field is always required and must look like this
   destination: String!
   amount: BigInt!
+  denom: String!
 }

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -93,7 +93,7 @@ export async function handleDistDelegatorClaim(message: CosmosMessage<DistDelega
 
 export async function handleLegacyBridgeSwap(message: CosmosMessage<LegacyBridgeSwapMsg>): Promise<void> {
   const swap = new LegacyBridgeSwap(`${message.tx.hash}-${message.idx}`);
-  const {destination, amount} = message.msg.decodedMsg.msg.legacyBridgeSwap;
+  const {destination, amount} = message.msg.decodedMsg.msg.swap;
 
   swap.destination = destination;
   swap.amount = BigInt(amount);

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -2,6 +2,7 @@ import {
   Block,
   DistDelegatorClaim,
   ExecuteContractMessage,
+  EventAttribute,
   Event,
   GovProposalVote,
   LegacyBridgeSwap,
@@ -83,7 +84,8 @@ export async function handleEvent(event: CosmosEvent): Promise<void> {
 
   const eventEntity = Event.create({
     id: `${messageId(event)}-${event.idx}`,
-    json: JSON.stringify(event.event),
+    type: event.event.type,
+    attributes: event.event.attributes as EventAttribute[],
     log: event.log.log,
     transactionId: event.tx.hash,
     blockId: event.block.block.id,

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -69,6 +69,7 @@ export async function handleMessage(msg: CosmosMessage): Promise<void> {
   logger.debug(`[handleMessage] (msg.msg): ${JSON.stringify(msg.msg, null, 2)}`)
   const msgEntity = Message.create({
     id: messageId(msg),
+    typeUrl: msg.msg.typeUrl,
     json: JSON.stringify(msg.msg.decodedMsg),
     transactionId: msg.tx.hash,
     blockId: msg.block.block.id,

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -1,113 +1,154 @@
-import {ExecuteEvent, Message, Transaction, LegacyBridgeSwap, DistDelegatorClaim, GovProposalVote} from "../types";
 import {
-  CosmosEvent,
-  CosmosBlock,
-  CosmosMessage,
-  CosmosTransaction,
-} from "@subql/types-cosmos";
-import { GovProposalVoteOption } from "../types/enums";
+  Block,
+  DistDelegatorClaim,
+  ExecuteContractMessage,
+  ExecuteEvent,
+  GovProposalVote,
+  LegacyBridgeSwap,
+  Message,
+  Transaction,
+  TxStatus
+} from "../types";
+import {CosmosBlock, CosmosEvent, CosmosMessage, CosmosTransaction,} from "@subql/types-cosmos";
+import {ExecuteContractMsg, DistDelegatorClaimMsg, GovProposalVoteMsg, LegacyBridgeSwapMsg} from "./types";
+
+// messageId returns the id of the message passed or
+// that of the message which generated the event passed.
+function messageId(msg: CosmosMessage | CosmosEvent): string {
+  return `${msg.tx.hash}-${msg.idx}`;
+}
 
 export async function handleBlock(block: CosmosBlock): Promise<void> {
-  // If you wanted to index each block in Cosmos (Juno), you could do that here
+  const {id, header: {chainId, height, time: timestamp}} = block.block;
+  const blockEntity = Block.create({
+    id,
+    chainId,
+    height: BigInt(height),
+    // TODO: convert to unix timestamp and store as Int.
+    timestamp,
+  });
+
+  await blockEntity.save()
 }
 
 export async function handleTransaction(tx: CosmosTransaction): Promise<void> {
-  const transactionRecord = Transaction.create({
+  let status = TxStatus.Error;
+  if (tx.tx.log) {
+    try {
+      JSON.parse(tx.tx.log)
+      status = TxStatus.Success;
+    } catch {
+      // NB: assume tx failed
+    }
+  }
+
+  const txEntity = Transaction.create({
     id: tx.hash,
-    blockHeight: BigInt(tx.block.block.header.height),
-    timestamp: tx.block.block.header.time,
+    blockId: tx.block.block.id,
     gasUsed: BigInt(Math.trunc(tx.tx.gasUsed)),
     gasWanted: BigInt(Math.trunc(tx.tx.gasWanted)),
-    // TODO:
-    // memo: tx.tx.
-    // fee: BigInt(Math.trunc(tx.)),
+    memo: tx.decodedTx.body.memo,
+    timeoutHeight: BigInt(tx.decodedTx.body.timeoutHeight.toString()),
+    fees: JSON.stringify(tx.decodedTx.authInfo.fee.amount),
+    log: tx.tx.log,
+    status,
   });
-  await transactionRecord.save();
+
+  await txEntity.save();
 }
 
 export async function handleMessage(msg: CosmosMessage): Promise<void> {
-  const messageRecord = Message.create({
-    id: `${msg.tx.hash}-${msg.idx}`,
-    blockHeight: BigInt(msg.block.block.header.height),
-    txHash: msg.tx.hash,
-    sender: msg.msg.decodedMsg.sender,
-    contract: msg.msg.decodedMsg.contract,
+  const msgEntity = Message.create({
+    id: messageId(msg),
+    json: JSON.stringify(msg.msg.decodedMsg),
+    transactionId: msg.tx.hash,
+    blockId: msg.block.block.id,
   });
-  await messageRecord.save();
+
+  await msgEntity.save();
 }
 
 export async function handleEvent(event: CosmosEvent): Promise<void> {
-  const eventRecord = ExecuteEvent.create({
-    id: `${event.tx.hash}-${event.msg.idx}-${event.idx}`,
-    blockHeight: BigInt(event.block.block.header.height),
-    txHash: event.tx.hash,
-    contractAddress: event.event.attributes.find(attr => attr.key === '_contract_address').value
+  const eventEntity = ExecuteEvent.create({
+    id: `${messageId(event)}-${event.idx}`,
+    json: JSON.stringify(event.event),
+    log: event.log.log,
+    transactionId: event.tx.hash,
+    blockId: event.block.block.id,
   });
 
-  await eventRecord.save();
+  await eventEntity.save();
 }
 
-interface GovProposalVoteMsg {
-    proposalId: string;
-    voter: string;
-    option: GovProposalVoteOption;
+export async function handleExecuteContractMessage(msg: CosmosMessage<ExecuteContractMsg>): Promise<void> {
+  const id = messageId(msg);
+  const msgEntity = ExecuteContractMessage.create({
+    id,
+    sender: msg.msg.decodedMsg.sender,
+    contract: msg.msg.decodedMsg.contract,
+    funds: JSON.stringify(msg.msg.decodedMsg.funds),
+    messageId: id,
+    transactionId: msg.tx.hash,
+    blockId: msg.block.block.id,
+  });
+
+  // NB: no need to update msg ids in txs.
+
+  await msgEntity.save();
 }
 
-interface DistDelegatorClaimMsg {
-  delegatorAddress: string;
-  validatorAddress: string;
-}
-
-interface Coin {
-  amount: string,
-  denom: string,
-}
-
-interface LegacyBridgeSwapMsg {
-  contract: string,
-  sender: string,
-  msg: {
-    swap: {
-      destination: string,
-      amount: bigint,
-    },
-  },
-  funds: Coin[]
-}
-
-export async function handleGovProposalVote(message: CosmosMessage<GovProposalVoteMsg>): Promise<void> {
-  const vote = new GovProposalVote(`${message.tx.hash}-${message.idx}`);
-  const {proposalId, voter, option} = message.msg.decodedMsg;
-
-  vote.proposalId = proposalId;
-  vote.voterAddress = voter;
-  vote.option = option;
+export async function handleGovProposalVote(msg: CosmosMessage<GovProposalVoteMsg>): Promise<void> {
+  const id = messageId(msg);
+  const {proposalId, voter, option} = msg.msg.decodedMsg;
+  const vote = GovProposalVote.create({
+    id,
+    proposalId: proposalId,
+    voterAddress: voter,
+    option: option,
+    messageId: id,
+    transactionId: msg.tx.hash,
+    blockId: msg.block.block.id,
+  });
 
   await vote.save();
 }
 
-export async function handleDistDelegatorClaim(message: CosmosMessage<DistDelegatorClaimMsg>): Promise<void> {
-  const claim = new DistDelegatorClaim(`${message.tx.hash}-${message.idx}`);
-  const {delegatorAddress, validatorAddress} = message.msg.decodedMsg;
+export async function handleDistDelegatorClaim(msg: CosmosMessage<DistDelegatorClaimMsg>): Promise<void> {
 
-  claim.delegatorAddress = delegatorAddress;
-  claim.validatorAddress = validatorAddress;
+  const id = messageId(msg);
+  const {delegatorAddress, validatorAddress} = msg.msg.decodedMsg;
+  const claim = DistDelegatorClaim.create({
+    id,
+    delegatorAddress,
+    validatorAddress,
+    messageId: id,
+    transactionId: msg.tx.hash,
+    blockId: msg.block.block.id,
+  });
 
   // TODO:
   // claim.amount =
+  // claim.denom =
 
   await claim.save();
 }
 
-export async function handleLegacyBridgeSwap(message: CosmosMessage<LegacyBridgeSwapMsg>): Promise<void> {
-  const legacySwap = new LegacyBridgeSwap(`${message.tx.hash}-${message.idx}`);
-  const {msg, funds} = message.msg.decodedMsg;
-  const {destination} = msg.swap;
-  const [{amount, denom}] = funds;
+export async function handleLegacyBridgeSwap(msg: CosmosMessage<LegacyBridgeSwapMsg>): Promise<void> {
 
-  legacySwap.destination = destination;
-  legacySwap.amount = BigInt(amount);
-  legacySwap.denom = denom;
+  const id = messageId(msg);
+  const {
+    msg: {swap: {destination}},
+    funds: [{amount, denom}]
+  } = msg.msg.decodedMsg;
+  const legacySwap = LegacyBridgeSwap.create({
+    id,
+    destination,
+    amount: BigInt(amount),
+    denom,
+    messageId: id,
+    transactionId: msg.tx.hash,
+    blockId: msg.block.block.id,
+  });
 
   await legacySwap.save();
 }

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -19,6 +19,8 @@ function messageId(msg: CosmosMessage | CosmosEvent): string {
 }
 
 export async function handleBlock(block: CosmosBlock): Promise<void> {
+  logger.info(`[handleBlock] (block.header.height): indexing block ${block.block.header.height}`)
+
   const {id, header: {chainId, height, time: timestamp}} = block.block;
   const blockEntity = Block.create({
     id,
@@ -32,6 +34,10 @@ export async function handleBlock(block: CosmosBlock): Promise<void> {
 }
 
 export async function handleTransaction(tx: CosmosTransaction): Promise<void> {
+  logger.info(`[handleTransaction] (block ${tx.block.block.header.height}): indexing transaction ${tx.idx + 1} / ${tx.block.txs.length}`)
+  logger.debug(`[handleTransaction] (tx.decodedTx): ${JSON.stringify(tx.decodedTx, null, 2)}`)
+  logger.debug(`[handleTransaction] (tx.tx.log): ${tx.tx.log}`)
+
   let status = TxStatus.Error;
   if (tx.tx.log) {
     try {
@@ -58,6 +64,8 @@ export async function handleTransaction(tx: CosmosTransaction): Promise<void> {
 }
 
 export async function handleMessage(msg: CosmosMessage): Promise<void> {
+  logger.info(`[handleMessage] (tx ${msg.tx.hash}): indexing message ${msg.idx + 1} / ${msg.tx.decodedTx.body.messages.length}`)
+  logger.debug(`[handleMessage] (msg.msg): ${JSON.stringify(msg.msg, null, 2)}`)
   const msgEntity = Message.create({
     id: messageId(msg),
     json: JSON.stringify(msg.msg.decodedMsg),
@@ -69,6 +77,10 @@ export async function handleMessage(msg: CosmosMessage): Promise<void> {
 }
 
 export async function handleEvent(event: CosmosEvent): Promise<void> {
+  logger.info(`[handleEvent] (tx ${event.tx.hash}): indexing event ${event.idx + 1} / ${event.tx.tx.events.length}`)
+  logger.debug(`[handleEvent] (event.event): ${JSON.stringify(event.event, null, 2)}`)
+  logger.debug(`[handleEvent] (event.log): ${JSON.stringify(event.log, null, 2)}`)
+
   const eventEntity = Event.create({
     id: `${messageId(event)}-${event.idx}`,
     json: JSON.stringify(event.event),
@@ -81,6 +93,9 @@ export async function handleEvent(event: CosmosEvent): Promise<void> {
 }
 
 export async function handleExecuteContractMessage(msg: CosmosMessage<ExecuteContractMsg>): Promise<void> {
+  logger.info(`[handleExecuteContractMessage] (tx ${msg.tx.hash}): indexing ExecuteContractMessage ${messageId(msg)}`)
+  logger.debug(`[handleExecuteContractMessage] (msg.msg): ${JSON.stringify(msg.msg, null, 2)}`)
+
   const id = messageId(msg);
   const msgEntity = ExecuteContractMessage.create({
     id,
@@ -98,6 +113,9 @@ export async function handleExecuteContractMessage(msg: CosmosMessage<ExecuteCon
 }
 
 export async function handleGovProposalVote(msg: CosmosMessage<GovProposalVoteMsg>): Promise<void> {
+  logger.info(`[handleGovProposalVote] (tx ${msg.tx.hash}): indexing GovProposalVote ${messageId(msg)}`)
+  logger.debug(`[handleGovProposalVote] (msg.msg): ${JSON.stringify(msg.msg, null, 2)}`)
+
   const id = messageId(msg);
   const {proposalId, voter, option} = msg.msg.decodedMsg;
   const vote = GovProposalVote.create({
@@ -114,6 +132,8 @@ export async function handleGovProposalVote(msg: CosmosMessage<GovProposalVoteMs
 }
 
 export async function handleDistDelegatorClaim(msg: CosmosMessage<DistDelegatorClaimMsg>): Promise<void> {
+  logger.info(`[handleDistDelegatorClaim] (tx ${msg.tx.hash}): indexing DistDelegatorClaim ${messageId(msg)}`)
+  logger.debug(`[handleDistDelegatorClaim] (msg.msg): ${JSON.stringify(msg.msg, null, 2)}`)
 
   const id = messageId(msg);
   const {delegatorAddress, validatorAddress} = msg.msg.decodedMsg;
@@ -134,6 +154,8 @@ export async function handleDistDelegatorClaim(msg: CosmosMessage<DistDelegatorC
 }
 
 export async function handleLegacyBridgeSwap(msg: CosmosMessage<LegacyBridgeSwapMsg>): Promise<void> {
+  logger.info(`[handleLegacyBridgeSwap] (tx ${msg.tx.hash}): indexing LegacyBridgeSwap ${messageId(msg)}`)
+  logger.debug(`[handleLegacyBridgeSwap] (msg.msg): ${JSON.stringify(msg.msg, null, 2)}`)
 
   const id = messageId(msg);
   const {

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -2,7 +2,7 @@ import {
   Block,
   DistDelegatorClaim,
   ExecuteContractMessage,
-  ExecuteEvent,
+  Event,
   GovProposalVote,
   LegacyBridgeSwap,
   Message,
@@ -69,7 +69,7 @@ export async function handleMessage(msg: CosmosMessage): Promise<void> {
 }
 
 export async function handleEvent(event: CosmosEvent): Promise<void> {
-  const eventEntity = ExecuteEvent.create({
+  const eventEntity = Event.create({
     id: `${messageId(event)}-${event.idx}`,
     json: JSON.stringify(event.event),
     log: event.log.log,

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -58,13 +58,21 @@ interface DistDelegatorClaimMsg {
   validatorAddress: string;
 }
 
+interface Coin {
+  amount: string,
+  denom: string,
+}
+
 interface LegacyBridgeSwapMsg {
+  contract: string,
+  sender: string,
   msg: {
-    legacyBridgeSwap: {
+    swap: {
       destination: string,
       amount: bigint,
-    }
-  }
+    },
+  },
+  funds: Coin[]
 }
 
 export async function handleGovProposalVote(message: CosmosMessage<GovProposalVoteMsg>): Promise<void> {
@@ -92,11 +100,14 @@ export async function handleDistDelegatorClaim(message: CosmosMessage<DistDelega
 }
 
 export async function handleLegacyBridgeSwap(message: CosmosMessage<LegacyBridgeSwapMsg>): Promise<void> {
-  const swap = new LegacyBridgeSwap(`${message.tx.hash}-${message.idx}`);
-  const {destination, amount} = message.msg.decodedMsg.msg.swap;
+  const legacySwap = new LegacyBridgeSwap(`${message.tx.hash}-${message.idx}`);
+  const {msg, funds} = message.msg.decodedMsg;
+  const {destination} = msg.swap;
+  const [{amount, denom}] = funds;
 
-  swap.destination = destination;
-  swap.amount = BigInt(amount);
+  legacySwap.destination = destination;
+  legacySwap.amount = BigInt(amount);
+  legacySwap.denom = denom;
 
-  await swap.save();
+  await legacySwap.save();
 }

--- a/src/mappings/types/common.ts
+++ b/src/mappings/types/common.ts
@@ -1,0 +1,4 @@
+export interface Coin {
+  amount: string,
+  denom: string,
+}

--- a/src/mappings/types/index.ts
+++ b/src/mappings/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./messages";

--- a/src/mappings/types/messages.ts
+++ b/src/mappings/types/messages.ts
@@ -1,0 +1,29 @@
+import {GovProposalVoteOption} from "../../types";
+import {Coin} from "./common";
+
+export interface ExecuteContractMsg {
+  sender: string;
+  contract: string;
+  funds?: Coin[];
+}
+
+export interface GovProposalVoteMsg {
+  proposalId: string;
+  voter: string;
+  option: GovProposalVoteOption;
+}
+
+export interface DistDelegatorClaimMsg {
+  delegatorAddress: string;
+  validatorAddress: string;
+}
+
+export interface LegacyBridgeSwapMsg extends ExecuteContractMsg{
+  msg: {
+    swap: {
+      destination: string,
+      amount: bigint,
+    },
+  },
+}
+


### PR DESCRIPTION
### Changes

- add [fetch subquery dictionary](https://explorer.subquery.network/subquery/subquery/cosmos-fetch-ai-dictionary) to project.yaml
- schema improvements
  - related entities are connected by an edge with the direction going from the more specific entity to the more general entity, in a one-to-one relationship; or from the many-side to the one-side, in a  or many-to-one relationship (i.e. the more specific entity / many-side holds the foreign key)
  - fix ExecuteEvent type name typo
  - add indexes
  - add reverse relationship lookups
  - de-duplicate fields
- specify the https port for the network endpoint (just in case :sunglasses:)
- register handler for all messages, events, transactions and blocks
  - collecting all available information such that more specific object types (e.g. `ExecuteContractMessage`, `LegacyBridgeSwap`) can be retroactively generated from this data (possibly via database migrations (?))


### Related Issues

- fetchai/ecosystem-tasks#43