### PR TITLE
fix: uncomment chainTypes

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -24,11 +24,11 @@ network:
 dataSources:
   - kind: cosmos/Runtime
     startBlock: 5300201 # first block on fetchhub-4
-    #chainTypes: # This is a beta feature that allows support for any Cosmos chain by importing the correct protobuf messages
-    #  cosmos.slashing.v1beta1:
-    #    file: "./proto/cosmos/slashing/v1beta1/tx.proto"
-    #    messages:
-    #     - "MsgUnjail"
+    chainTypes: # This is a beta feature that allows support for any Cosmos chain by importing the correct protobuf messages
+      cosmos.slashing.v1beta1:
+        file: "./proto/cosmos/slashing/v1beta1/tx.proto"
+        messages:
+         - "MsgUnjail"
     mapping:
       file: "./dist/index.js"
       handlers:


### PR DESCRIPTION
### Changes

- Uncomment `chainTypes` in the project.yaml to prevent the following error:

```
failed to index block at height 5585256 handleMessage([{"idx":0,"tx":{"idx":0,"block":{"block":{"id":"E105D0370D8C594E73CC23BDE0E43422512643B07709F9C40275B05923F8767F","header":{"version":{"block":"11","app":"0"},"height":5585256,"chainId":"fetchhub-4","time":"2022-04-25T15:15:38.385747527Z"},"txs":[{"0":10,"1":93,"2":10,"3":91,"4":10,"5":34,"6":47,"7":99,"8":111,"9":115,"10":109,"11":111,"12":115,"13":46,"14":115,"15":108,"16":97,"17":115,"18":104,"19":105,"20":110,"21":103,"22":46,"23":118,"24":49,"25":98,"26":101,"27":116,"28":97,"29":49,"30":46,"31":77,"32":115,"33":103,"34":85,"35":110,"36":106,"37":97,"38... Error: Unregistered type url: /cosmos.slashing.v1beta1.MsgUnjail at Registry.lookupTypeWithError (/usr/local/lib/node_modules/@subql/node-cosmos/node_modules/@cosmjs/proto-signing/build/registry.js:74:19) at Registry.decode (/usr/local/lib/node_modules/@subql/node-cosmos/node_modules/@cosmjs/proto-signing/build/registry.js:117:27) at CosmosClient.decodeMsg (/usr/local/lib/node_modules/@subql/node-cosmos/dist/indexer/api.service.js:148:46) at Object.get decodedMsg (/usr/local/lib/node_modules/@subql/node-cosmos/dist/utils/cosmos.js:122:47) at get (<anonymous>) at BaseHandler.get (/usr/local/lib/node_modules/@subql/node-cosmos/node_modules/vm2/lib/bridge.js:441:11) at JSON.stringify (<anonymous>) at Object.e.handleMessage (/tmp/NClDJM/QmcUD4ysek4FiU2Tm5T1rUFvbt7WubbxFNQeNM9ffbLX1u.js:2:1232) at /tmp/NClDJM/sandbox:2:50 at BaseHandler.apply (/usr/local/lib/node_modules/@subql/node-cosmos/node_modules/vm2/lib/bridge.js:479:11)
```