### PR TITLE
chore: add run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+docker compose up -d
+yarn codegen
+yarn build
+yarn subql-node-cosmos --db-schema app --force-clean


### PR DESCRIPTION
- Include a simple `run.sh` script to start the Subquery indexer