### PR TITLE
chore: subquery db storage size default value

### DIFF
--- a/k8s/subquery/values.yaml
+++ b/k8s/subquery/values.yaml
@@ -29,4 +29,4 @@ db:
   gcpProject: fetch-ai-sandbox
   gcpSecret: sandbox_subquery_postgres
 
-  storageSize: 1Gi
+  storageSize: 7Gi


### PR DESCRIPTION
### Changes

Increases the default helm value for the size of the persistent volume from 1[Gi](https://simple.wikipedia.org/wiki/Gibibyte) to 7Gi. This default value only applies when using the helm cli, (e.g. `helm install <chart instance name> ./k8s/subquery/ -f ./k8s/subquery/values.yaml -n subquery`). This is only the case while experimenting in the sandbox.

### Related Issue
fetchai/ecosystem-tasks#114