### PR TITLE
fix: subquery node entrypoint

### DIFF
--- a/docker/node.dockerfile
+++ b/docker/node.dockerfile
@@ -28,6 +28,7 @@ COPY --from=builder /app/dist /app/dist
 ADD ./proto /app/proto
 ADD ./project.yaml schema.graphql /app/
 ADD ./scripts/node-entrypoint.sh /entrypoint.sh
+ADD ./scripts/error-check.js /error-check.js
 
 RUN chmod +x /error-check.js
 

--- a/docker/node.dockerfile
+++ b/docker/node.dockerfile
@@ -29,4 +29,6 @@ ADD ./proto /app/proto
 ADD ./project.yaml schema.graphql /app/
 ADD ./scripts/node-entrypoint.sh /entrypoint.sh
 
+RUN chmod +x /error-check.js
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/error-check.js
+++ b/scripts/error-check.js
@@ -1,0 +1,75 @@
+#! /usr/bin/env node
+
+/* This script is intended to wrap an entrypoint binary call in order
+    to catch specific fatal errors by observing STDOUT. When matching
+    fatal errors are detected, the application will restart and the
+    container entrypoint will not exit.
+ */
+
+const {spawn} = require('child_process');
+const {argv, exit, stdout, stderr} = require('process');
+
+const restartTimeoutMs = 1000;
+const maxRecentErrsLen = 3;
+const ignoredErrorRegexes = [
+  /^.*failed to index block at height \d+\s+Error: read ECONNRESET\s*$/,
+];
+
+const [_, __, entrypoint, ...args] = argv;
+
+runEntrypoint();
+
+function runEntrypoint() {
+  const recentIgnoredErrors = [];
+  const proc = spawn(entrypoint, args);
+
+  // Always forward STDERR
+  proc.stderr.on("data", (data) => stderr.write(data));
+  proc.stdout.on("data", (data) => {
+    // Always forward STDOUT
+    stdout.write(data);
+
+    // NB: *all* subquery-node logs go to STDOUT
+    for (const re of ignoredErrorRegexes) {
+      if (re.test(data.toString())) {
+        const recentErrsLen = recentIgnoredErrors.length;
+        if (recentErrsLen < maxRecentErrsLen) {
+          recentIgnoredErrors.splice(0, maxRecentErrsLen - recentErrsLen, data.toString());
+        }
+
+        console.error("FATAL ERROR: error-check.js match found - restarting entrypoint");
+
+        // Ensure the child process is exited
+        if (proc.exitCode === null) {
+          // TODO: leave running instead?
+          proc.kill();
+        }
+
+        // Restart child process
+        setTimeout(() => {
+          runEntrypoint(entrypoint, args);
+        }, restartTimeoutMs);
+      }
+    }
+  });
+
+  proc.on("close", (code) => {
+    // Wait for logs to be processed
+    setTimeout(() => {
+      const foundIgnoredErrors = recentIgnoredErrors.find(err => {
+        for (const re of ignoredErrorRegexes) {
+          if (re.test(err)) {
+            return true;
+          }
+        }
+        return false;
+      });
+
+      // Only exit if no ignoredErrors found
+      if (typeof (foundIgnoredErrors) === "undefined") {
+        // Exit with same code
+        exit(code);
+      }
+    }, 100);
+  });
+}

--- a/scripts/node-entrypoint.sh
+++ b/scripts/node-entrypoint.sh
@@ -18,4 +18,4 @@ if [[ ! -z "${NETWORK_ENDPOINT}" ]]; then
 fi
 
 # run the main node
-exec /sbin/tini -- /usr/local/lib/node_modules/@subql/node-cosmos/bin/run
+exec /sbin/tini -- /error-check.js "/usr/local/lib/node_modules/@subql/node-cosmos/bin/run"


### PR DESCRIPTION
### Changes

Adds error-check node script to watch entrypoint stderr for specific fatal errors, which when encountered, cause the script to restart the entrypoint without the container exiting.
