### PR TITLE
chore: change block timestamp to Date type

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -20,7 +20,7 @@ type Block @entity {
   id: ID! # The block header hash
   chainId: String! @index
   height: BigInt! @index
-  timestamp: String!
+  timestamp: Date!
   transactions: [Transaction] @derivedFrom(field: "block")
   messages: [Message] @derivedFrom(field: "block")
   events: [Event] @derivedFrom(field: "block")

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -30,12 +30,12 @@ function messageId(msg: CosmosMessage | CosmosEvent): string {
 export async function handleBlock(block: CosmosBlock): Promise<void> {
   logger.info(`[handleBlock] (block.header.height): indexing block ${block.block.header.height}`)
 
-  const {id, header: {chainId, height, time: timestamp}} = block.block;
+  const {id, header: {chainId, height, time}} = block.block;
+  const timestamp = new Date(time);
   const blockEntity = Block.create({
     id,
     chainId,
     height: BigInt(height),
-    // TODO: convert to unix timestamp and store as Int.
     timestamp,
   });
 


### PR DESCRIPTION
### Changes

_(Extracted from #28)_

- changes block timestamp data type from `String` to `Date`