### PR TITLE
test: tidying up e2e tests

### DIFF
--- a/test/helpers/field_enums.py
+++ b/test/helpers/field_enums.py
@@ -62,3 +62,68 @@ class EventFields(NamedFields):
     def select_query(cls, table="events"):
         return super().select_query(table)
 
+
+class NativeTransferFields(NamedFields):
+    id = 0
+    amounts = 1
+    denom = 2
+    to_address = 3
+    from_address = 4
+
+    @classmethod
+    def select_query(cls, table="native_transfers"):
+        return super().select_query(table)
+
+
+class LegacyBridgeSwapFields(NamedFields):
+    id = 0
+    message_id = 1
+    transaction_id = 2
+    block_id = 3
+    destination = 4
+    amount = 5
+    denom = 6
+
+    @classmethod
+    def select_query(cls, table="legacy_bridge_swaps"):
+        return super().select_query(table)
+
+
+class GovProposalVoteFields(NamedFields):
+    id = 0
+    message_id = 1
+    transaction_id = 2
+    block_id = 3
+    proposal_id = 4
+    voter_address = 5
+    option = 6
+
+    @classmethod
+    def select_query(cls, table="gov_proposal_votes"):
+        return super().select_query(table)
+
+
+class ExecuteContractMessageFields(NamedFields):
+    id = 0
+    message_id = 1
+    transaction_id = 2
+    contract = 3
+    method = 4
+    funds = 5
+
+    @classmethod
+    def select_query(cls, table="execute_contract_messages"):
+        return super().select_query(table)
+
+
+class DistDelegatorClaimFields(NamedFields):
+    id = 0
+    message_id = 1
+    transaction_id = 2
+    block_id = 3
+    delegator_address = 4
+    validator_address = 5
+
+    @classmethod
+    def select_query(cls, table="dist_delegator_claims"):
+        return super().select_query(table)

--- a/test/test_delegation_reward_claim.py
+++ b/test/test_delegation_reward_claim.py
@@ -7,24 +7,24 @@ class TestDelegation(base.Base):
     amount = 100
     db_query = 'SELECT delegator_address, validator_address from dist_delegator_claims'
 
-    def setUp(self):
-        delegate_tx = self.ledger_client.delegate_tokens(self.validator_operator_address, self.amount, self.validator_wallet)
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.clean_db({"dist_delegator_claims"})
+
+        delegate_tx = cls.ledger_client.delegate_tokens(cls.validator_operator_address, cls.amount, cls.validator_wallet)
         delegate_tx.wait_to_complete()
-        self.assertTrue(delegate_tx.response.is_successful(), "\nTXError: delegation tx unsuccessful")
+        cls.assertTrue(delegate_tx.response.is_successful(), "\nTXError: delegation tx unsuccessful")
 
-    def test_claim_rewards(self):
-        self.db_cursor.execute('TRUNCATE table dist_delegator_claims')
-        self.db.commit()
-        self.assertFalse(self.db_cursor.execute(self.db_query).fetchall(), "\nDBError: table not empty after truncation")
-
-        claim_tx = self.ledger_client.claim_rewards(self.validator_operator_address, self.validator_wallet)
+        claim_tx = cls.ledger_client.claim_rewards(cls.validator_operator_address, cls.validator_wallet)
         claim_tx.wait_to_complete()
-        self.assertTrue(claim_tx.response.is_successful(), "\nTXError: reward claim tx unsuccessful")
+        cls.assertTrue(claim_tx.response.is_successful(), "\nTXError: reward claim tx unsuccessful")
 
         # primitive solution to wait for indexer to observe and handle new tx - TODO: add robust solution
         time.sleep(5)
 
-        row = self.db_cursor.execute(self.db_query).fetchone()
+    def test_claim_rewards(self):
+        row = self.db_cursor.execute(DistDelegatorClaimFields.select_query()).fetchone()
         self.assertIsNotNone(row, "\nDBError: table is empty - maybe indexer did not find an entry?")
         self.assertEqual(row[0], self.validator_address, "\nDBError: delegation address does not match")
         self.assertEqual(row[1], self.validator_operator_address, "\nDBError: delegation address does not match")

--- a/test/test_delegation_reward_claim.py
+++ b/test/test_delegation_reward_claim.py
@@ -2,10 +2,11 @@ import base
 from gql import gql
 import time, unittest, datetime as dt, json
 
+from helpers.field_enums import DistDelegatorClaimFields
+
 
 class TestDelegation(base.Base):
     amount = 100
-    db_query = 'SELECT delegator_address, validator_address from dist_delegator_claims'
 
     @classmethod
     def setUpClass(cls):
@@ -26,8 +27,8 @@ class TestDelegation(base.Base):
     def test_claim_rewards(self):
         row = self.db_cursor.execute(DistDelegatorClaimFields.select_query()).fetchone()
         self.assertIsNotNone(row, "\nDBError: table is empty - maybe indexer did not find an entry?")
-        self.assertEqual(row[0], self.validator_address, "\nDBError: delegation address does not match")
-        self.assertEqual(row[1], self.validator_operator_address, "\nDBError: delegation address does not match")
+        self.assertEqual(row[DistDelegatorClaimFields.delegator_address.value], self.validator_address, "\nDBError: delegation address does not match")
+        self.assertEqual(row[DistDelegatorClaimFields.validator_address.value], self.validator_operator_address, "\nDBError: delegation address does not match")
 
     def test_retrieve_claim(self):  # As of now, this test depends on the execution of the previous test in this class.
         result = self.get_latest_block_timestamp()

--- a/test/test_delegation_reward_claim.py
+++ b/test/test_delegation_reward_claim.py
@@ -66,7 +66,7 @@ class TestDelegation(base.Base):
                 distDelegatorClaims (
                 filter: {
                     validatorAddress: { 
-                        equalTo:\""""+str(self.validator_operator_address)+"""\"
+                        equalTo:\"""" + str(self.validator_operator_address) + """\"
                     }
                 }) {
                     nodes {
@@ -86,7 +86,7 @@ class TestDelegation(base.Base):
                 distDelegatorClaims (
                 filter: {
                     delegatorAddress: { 
-                        equalTo:\""""+str(self.validator_address)+"""\"
+                        equalTo:\"""" + str(self.validator_address) + """\"
                     }
                 }) {
                     nodes {

--- a/test/test_delegation_reward_claim.py
+++ b/test/test_delegation_reward_claim.py
@@ -1,7 +1,11 @@
-import base
-from gql import gql
-import time, unittest, datetime as dt, json
+import datetime as dt
+import json
+import time
+import unittest
 
+from gql import gql
+
+import base
 from helpers.field_enums import DistDelegatorClaimFields
 
 

--- a/test/test_delegation_reward_claim.py
+++ b/test/test_delegation_reward_claim.py
@@ -31,10 +31,10 @@ class TestDelegation(base.Base):
         self.assertEqual(row[DistDelegatorClaimFields.validator_address.value], self.validator_operator_address, "\nDBError: delegation address does not match")
 
     def test_retrieve_claim(self):  # As of now, this test depends on the execution of the previous test in this class.
-        result = self.get_latest_block_timestamp()
-        time_before = result - dt.timedelta(minutes=5)  # create a second timestamp for five minutes before
-        time_before = json.dumps(time_before.isoformat())  # convert both to JSON ISO format
-        time_latest = json.dumps(result.isoformat())
+        latest_block_timestamp = self.get_latest_block_timestamp()
+        # create a second timestamp for five minutes before
+        min_timestamp = (latest_block_timestamp - dt.timedelta(minutes=5)).isoformat()  # convert both to JSON ISO format
+        max_timestamp = latest_block_timestamp.isoformat()
 
         # query governance votes, query related block and filter by timestamp, returning all within last five minutes
         query_by_timestamp = gql(
@@ -44,8 +44,8 @@ class TestDelegation(base.Base):
                 filter: {
                     block: {
                     timestamp: {
-                        greaterThanOrEqualTo: """ + time_before + """,
-                                lessThanOrEqualTo: """ + time_latest + """
+                        greaterThanOrEqualTo: """ + json.dumps(min_timestamp) + """,
+                                lessThanOrEqualTo: """ + json.dumps(max_timestamp) + """
                             }
                         }
                     }) {

--- a/test/test_execute_contract_message.py
+++ b/test/test_execute_contract_message.py
@@ -2,12 +2,13 @@ from gql import gql
 from base_contract import BaseContract
 import time, unittest, datetime as dt, json
 
+from helpers.field_enums import ExecuteContractMessageFields
+
 
 class TestContractExecution(BaseContract):
     amount = '10000'
     denom = "atestfet"
     method = 'swap'
-    db_query = 'SELECT contract, method, funds from execute_contract_messages'
 
     @classmethod
     def setUpClass(cls):
@@ -24,12 +25,12 @@ class TestContractExecution(BaseContract):
         time.sleep(12)
 
     def test_contract_execution(self):
-        row = self.db_cursor.execute(self.db_query).fetchone()
-        self.assertIsNotNone(row, "\nDBError: table is empty - maybe indexer did not find an entry?")
-        self.assertEqual(row[0], self.contract.address, "\nDBError: contract address does not match")
-        self.assertEqual(row[1], self.method, "\nDBError: contract method does not match")
-        self.assertEqual(row[2][0]["amount"], self.amount, "\nDBError: fund amount does not match")
-        self.assertEqual(row[2][0]["denom"], self.denom, "\nDBError: fund denomination does not match")
+        execMsgs = self.db_cursor.execute(ExecuteContractMessageFields.select_query()).fetchone()
+        self.assertIsNotNone(execMsgs, "\nDBError: table is empty - maybe indexer did not find an entry?")
+        self.assertEqual(execMsgs[ExecuteContractMessageFields.contract.value], self.contract.address, "\nDBError: contract address does not match")
+        self.assertEqual(execMsgs[ExecuteContractMessageFields.method.value], self.method, "\nDBError: contract method does not match")
+        self.assertEqual(execMsgs[ExecuteContractMessageFields.funds.value][0]["amount"], self.amount, "\nDBError: fund amount does not match")
+        self.assertEqual(execMsgs[ExecuteContractMessageFields.funds.value][0]["denom"], self.denom, "\nDBError: fund denomination does not match")
 
     def test_contract_execution_retrieval(self):  # As of now, this test depends on the execution of the previous test in this class.
         result = self.get_latest_block_timestamp()

--- a/test/test_execute_contract_message.py
+++ b/test/test_execute_contract_message.py
@@ -1,7 +1,11 @@
-from gql import gql
-from base_contract import BaseContract
-import time, unittest, datetime as dt, json
+import datetime as dt
+import json
+import time
+import unittest
 
+from gql import gql
+
+from base_contract import BaseContract
 from helpers.field_enums import ExecuteContractMessageFields
 
 

--- a/test/test_execute_contract_message.py
+++ b/test/test_execute_contract_message.py
@@ -68,7 +68,7 @@ class TestContractExecution(BaseContract):
                 executeContractMessages (
                 filter: {
                     method: {
-                        equalTo:\""""+str(self.method)+"""\"
+                        equalTo:\"""" + str(self.method) + """\"
                     }
                 }) {
                     nodes {

--- a/test/test_gov_proposal_vote.py
+++ b/test/test_gov_proposal_vote.py
@@ -1,10 +1,15 @@
-from cosmpy.aerial.tx import Transaction
-from cosmpy.protos.cosmos.gov.v1beta1 import tx_pb2 as gov_tx, gov_pb2
-from cosmpy.protos.cosmos.base.v1beta1 import coin_pb2
 from cosmpy.aerial.client import utils
+from cosmpy.aerial.tx import Transaction
+from cosmpy.protos.cosmos.base.v1beta1 import coin_pb2
+from cosmpy.protos.cosmos.gov.v1beta1 import tx_pb2 as gov_tx, gov_pb2
 from google.protobuf import any_pb2
 from gql import gql
-import base, json, time, unittest, datetime as dt
+
+import base
+import datetime as dt
+import json
+import time
+import unittest
 from helpers.field_enums import GovProposalVoteFields
 
 

--- a/test/test_gov_proposal_vote.py
+++ b/test/test_gov_proposal_vote.py
@@ -98,7 +98,7 @@ class TestGovernance(base.Base):
                 govProposalVotes (
                 filter: {
                     voterAddress: {
-                        equalTo: \""""+str(self.validator_address)+"""\"
+                        equalTo: \"""" + str(self.validator_address) + """\"
                     }
                 }) {
                     nodes {
@@ -118,7 +118,7 @@ class TestGovernance(base.Base):
                 govProposalVotes (
                 filter: {
                     option: {
-                        equalTo: """+self.option+"""
+                        equalTo: """ + self.option + """
                     }
                 }) {
                     nodes {

--- a/test/test_gov_proposal_vote.py
+++ b/test/test_gov_proposal_vote.py
@@ -5,6 +5,7 @@ from cosmpy.aerial.client import utils
 from google.protobuf import any_pb2
 from gql import gql
 import base, json, time, unittest, datetime as dt
+from helpers.field_enums import GovProposalVoteFields
 
 
 class TestGovernance(base.Base):
@@ -12,7 +13,6 @@ class TestGovernance(base.Base):
     denom = "atestfet"
     amount = "10000000"
     option = 'YES'
-    db_query = 'SELECT voter_address, option from gov_proposal_votes'
 
     @classmethod
     def setUpClass(cls):
@@ -57,10 +57,10 @@ class TestGovernance(base.Base):
         # primitive solution to wait for indexer to observe and handle new tx - TODO: add robust solution
         time.sleep(5)
 
-        row = self.db_cursor.execute(self.db_query).fetchone()
-        self.assertIsNotNone(row, "\nDBError: table is empty - maybe indexer did not find an entry?")
-        self.assertEqual(row[0], self.validator_address, "\nDBError: voter address does not match")
-        self.assertEqual(row[1], self.option, "\nDBError: voter option does not match")
+        vote = self.db_cursor.execute(GovProposalVoteFields.select_query()).fetchone()
+        self.assertIsNotNone(vote, "\nDBError: table is empty - maybe indexer did not find an entry?")
+        self.assertEqual(vote[GovProposalVoteFields.voter_address.value], self.validator_address, "\nDBError: voter address does not match")
+        self.assertEqual(vote[GovProposalVoteFields.option.value], self.option, "\nDBError: voter option does not match")
 
     def test_retrieve_vote(self):  # As of now, this test depends on the execution of the previous test in this class.
         result = self.get_latest_block_timestamp()

--- a/test/test_legacy_bridge_swap.py
+++ b/test/test_legacy_bridge_swap.py
@@ -1,7 +1,12 @@
-from gql import gql
-from base_contract import BaseContract
-import time, unittest, decimal, datetime as dt, json
+import datetime as dt
+import decimal
+import json
+import time
+import unittest
 
+from gql import gql
+
+from base_contract import BaseContract
 from helpers.field_enums import LegacyBridgeSwapFields
 
 

--- a/test/test_legacy_bridge_swap.py
+++ b/test/test_legacy_bridge_swap.py
@@ -9,28 +9,28 @@ class TestContractSwap(BaseContract):
     denom = "atestfet"
     db_query = 'SELECT destination, amount, denom from legacy_bridge_swaps'\
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.clean_db({"legacy_bridge_swaps"})
 
-    def test_contract_swap(self):
-        self.db_cursor.execute('TRUNCATE table legacy_bridge_swaps')
-        self.db.commit()
-        self.assertFalse(self.db_cursor.execute(self.db_query).fetchall(), "\nDBError: table not empty after truncation")
-
-        self.contract.execute(
-            {"swap": {"destination": self.validator_address}},
-            self.validator_wallet,
-            funds=str(self.amount)+self.denom
+        cls.contract.execute(
+            {"swap": {"destination": cls.validator_address}},
+            cls.validator_wallet,
+            funds=str(cls.amount)+cls.denom
         )
 
         # primitive solution to wait for indexer to observe and handle new tx - TODO: add robust solution
         time.sleep(12)
 
-        row = self.db_cursor.execute(self.db_query).fetchone()
-        self.assertIsNotNone(row, "\nDBError: table is empty - maybe indexer did not find an entry?")
-        self.assertEqual(row[0], self.validator_address, "\nDBError: swap sender address does not match")
-        self.assertEqual(row[1], self.amount, "\nDBError: fund amount does not match")
-        self.assertEqual(row[2], self.denom, "\nDBError: fund denomination does not match")
+    def test_contract_swap(self):
+        swap = self.db_cursor.execute(LegacyBridgeSwapFields.select_query()).fetchone()
+        self.assertIsNotNone(swap, "\nDBError: table is empty - maybe indexer did not find an entry?")
+        self.assertEqual(swap[LegacyBridgeSwapFields.destination.value], self.validator_address, "\nDBError: swap sender address does not match")
+        self.assertEqual(swap[LegacyBridgeSwapFields.amount.value], self.amount, "\nDBError: fund amount does not match")
+        self.assertEqual(swap[LegacyBridgeSwapFields.denom.value], self.denom, "\nDBError: fund denomination does not match")
 
-    def test_retrieve_swap(self):  # As of now, this test depends on the execution of the previous test in this class.
+    def test_retrieve_swap(self):
         result = self.get_latest_block_timestamp()
         time_before = result - dt.timedelta(minutes=5)  # create a second timestamp for five minutes before
         time_before = json.dumps(time_before.isoformat())  # convert both to JSON ISO format

--- a/test/test_legacy_bridge_swap.py
+++ b/test/test_legacy_bridge_swap.py
@@ -107,11 +107,11 @@ class TestContractSwap(BaseContract):
             This provides {"destination":destination address, "amount":amount, "denom":denomination}
             which can be destructured for the values of interest.
             """
-            message = result["legacyBridgeSwaps"]["nodes"]
-            self.assertTrue(message, "\nGQLError: No results returned from query")
-            self.assertEqual(message[0]["destination"], self.validator_address, "\nGQLError: swap destination address does not match")
-            self.assertEqual(int(message[0]["amount"]), int(self.amount), "\nGQLError: fund amount does not match")
-            self.assertEqual(message[0]["denom"], self.denom, "\nGQLError: fund denomination does not match")
+            swaps = result["legacyBridgeSwaps"]["nodes"]
+            self.assertNotEqual(swaps, [], "\nGQLError: No results returned from query")
+            self.assertEqual(swaps[0]["destination"], self.validator_address, "\nGQLError: swap destination address does not match")
+            self.assertEqual(int(swaps[0]["amount"]), int(self.amount), "\nGQLError: fund amount does not match")
+            self.assertEqual(swaps[0]["denom"], self.denom, "\nGQLError: fund denomination does not match")
 
 
 if __name__ == '__main__':

--- a/test/test_legacy_bridge_swap.py
+++ b/test/test_legacy_bridge_swap.py
@@ -1,13 +1,13 @@
-from cosmpy.aerial.contract import LedgerContract
 from gql import gql
 from base_contract import BaseContract
 import time, unittest, decimal, datetime as dt, json
+
+from helpers.field_enums import LegacyBridgeSwapFields
 
 
 class TestContractSwap(BaseContract):
     amount = decimal.Decimal(10000)
     denom = "atestfet"
-    db_query = 'SELECT destination, amount, denom from legacy_bridge_swaps'\
 
     @classmethod
     def setUpClass(cls):

--- a/test/test_native_primitives.py
+++ b/test/test_native_primitives.py
@@ -32,24 +32,15 @@ class TestNativePrimitives(base.Base):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
-        cls.db_cursor.execute(f"TRUNCATE table {', '.join(cls.tables)} CASCADE")
-        cls.db.commit()
-
-        for table in list(reversed(cls.tables)):
-            results = cls.db_cursor.execute(f"SELECT id FROM {table}").fetchall()
-            if len(results) != 0:
-                raise Exception(f"truncation of table \"{table}\" failed, {len(results)} records remain")
+        cls.clean_db()
 
         tx = cls.ledger_client.send_tokens(cls.delegator_address, cls.amount, cls.denom, cls.validator_wallet)
         tx.wait_to_complete()
-        if not tx.response.is_successful():
-            raise Exception(f"first set-up tx failed")
+        cls.assertTrue(tx.response.is_successful(), f"first set-up tx failed")
 
         tx = cls.ledger_client.send_tokens(cls.validator_address, int(cls.amount / 10), cls.denom, cls.delegator_wallet)
         tx.wait_to_complete()
-        if not tx.response.is_successful():
-            raise Exception(f"second set-up tx failed")
+        cls.assertTrue(tx.response.is_successful(), f"second set-up tx failed")
 
         # Wait for subql node to sync
         time.sleep(5)

--- a/test/test_native_primitives.py
+++ b/test/test_native_primitives.py
@@ -1,9 +1,7 @@
 import json
-import re
 
 from gql import gql
 
-import base
 import time
 import unittest
 

--- a/test/test_native_transfer.py
+++ b/test/test_native_transfer.py
@@ -1,12 +1,13 @@
 from gql import gql
 import time, unittest, base, dateutil.parser as dp, datetime as dt, json
 
+from helpers.field_enums import NativeTransferFields
+
 
 class TestNativeTransfer(base.Base):
     amount = 5000000
     denom = "atestfet"
     msg_type = '/cosmos.bank.v1beta1.MsgSend'
-    db_query = 'SELECT amounts, denom, to_address, from_address from native_transfers'
 
     @classmethod
     def setUpClass(cls):
@@ -23,10 +24,10 @@ class TestNativeTransfer(base.Base):
     def test_native_transfer(self):
         native_transfer = self.db_cursor.execute(NativeTransferFields.select_query()).fetchone()
         self.assertIsNotNone(native_transfer, "\nDBError: table is empty - maybe indexer did not find an entry?")
-        self.assertEqual(native_transfer[0][0]['amount'], str(self.amount), "\nDBError: fund amount does not match")
-        self.assertEqual(native_transfer[1], self.denom, "\nDBError: fund denomination does not match")
-        self.assertEqual(native_transfer[2], self.delegator_address, "\nDBError: swap sender address does not match")
-        self.assertEqual(native_transfer[3], self.validator_address, "\nDBError: sender address does not match")
+        self.assertEqual(native_transfer[NativeTransferFields.amounts.value][0]['amount'], str(self.amount), "\nDBError: fund amount does not match")
+        self.assertEqual(native_transfer[NativeTransferFields.denom.value], self.denom, "\nDBError: fund denomination does not match")
+        self.assertEqual(native_transfer[NativeTransferFields.to_address.value], self.delegator_address, "\nDBError: swap sender address does not match")
+        self.assertEqual(native_transfer[NativeTransferFields.from_address.value], self.validator_address, "\nDBError: sender address does not match")
 
     def test_retrieve_transfer(self):  # As of now, this test depends on the execution of the previous test in this class.
         result = self.get_latest_block_timestamp()

--- a/test/test_native_transfer.py
+++ b/test/test_native_transfer.py
@@ -1,5 +1,10 @@
+import base
+import datetime as dt
+import json
+import time
+import unittest
+
 from gql import gql
-import time, unittest, base, dateutil.parser as dp, datetime as dt, json
 
 from helpers.field_enums import NativeTransferFields
 

--- a/test/test_native_transfer.py
+++ b/test/test_native_transfer.py
@@ -128,11 +128,11 @@ class TestNativeTransfer(base.Base):
             This provides {"toAddress":address, "fromAddress":address, "denom":denom, "amount":["amount":amount, "denom":denom]}
             which can be destructured for the values of interest.
             """
-            message = result["nativeTransfers"]["nodes"]
-            self.assertTrue(message, "\nGQLError: No results returned from query")
-            self.assertEqual(message[0]["denom"], self.denom, "\nGQLError: fund denomination does not match")
-            self.assertEqual(message[0]["toAddress"], self.delegator_address, "\nGQLError: destination address does not match")
-            self.assertEqual(message[0]["fromAddress"], self.validator_address, "\nGQLError: from address does not match")
+            native_transfers = result["nativeTransfers"]["nodes"]
+            self.assertNotEqual(native_transfers, [], "\nGQLError: No results returned from query")
+            self.assertEqual(native_transfers[0]["denom"], self.denom, "\nGQLError: fund denomination does not match")
+            self.assertEqual(native_transfers[0]["toAddress"], self.delegator_address, "\nGQLError: destination address does not match")
+            self.assertEqual(native_transfers[0]["fromAddress"], self.validator_address, "\nGQLError: from address does not match")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Changes

- refactors all DB cleanup code to `Base.clean_db`
- move applicable test setup code to `setUpClass` methods to reduce run-time
- add enum classes to represent DB tables' columns for clearer data access semantics with psycopg3
- rename some variables for clarity
- add spacing around operators
- tidy up imports