### PR TITLE
chore: run e2e tests in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@ dist/
 package-lock.json
 
 # Node Specific
-node_modules/
+*/node_modules/
 
 # Deployment
 k8s/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: End-to-end tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Update
+        run: sudo apt update
+      - name: Install OS dependencies
+        run: sudo apt install -y python3-dev
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Start-up local test environment
+        uses: isbang/compose-action@v1.2.0
+
+      # NB: doing this here gives the test env time to come up
+      - name: Install test dependencies
+        uses: palewire/install-python-pipenv-pipfile@v2
+        with:
+          python-version: 3.9
+
+      - name: Run end-to-end tests
+        run: pipenv run python -m unittest discover -s ./test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Start-up local test environment
         uses: isbang/compose-action@v1.2.0
+        with:
+          compose-file: "./ci-compose.yml"
 
       # NB: doing this here gives the test env time to come up
       - name: Install test dependencies

--- a/ci-compose.yml
+++ b/ci-compose.yml
@@ -1,0 +1,82 @@
+version: "3"
+
+services:
+  postgres:
+    image: postgres:14-alpine
+    ports:
+      - 5432:5432
+    volumes:
+      - .data/postgres:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: "subquery"
+      POSTGRES_PASSWORD: "subquery"
+      POSTGRES_DB: "subquery"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U subquery"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  subquery-node:
+    build:
+      context: .
+      dockerfile: ./docker/node.dockerfile
+    depends_on:
+      "postgres":
+        condition: service_healthy
+      "fetch-node":
+        condition: service_started
+    restart: always
+    environment:
+      DB_USER: "subquery"
+      DB_PASS: "subquery"
+      DB_DATABASE: "subquery"
+      DB_HOST: postgres
+      DB_PORT: 5432
+      START_BLOCK: "1"
+      NETWORK_ENDPOINT: "http://fetch-node:26657"
+      CHAIN_ID: "testing"
+    command:
+      - -f=/app
+      - --db-schema=app
+      - --batch-size=1
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://subquery-node:3000/ready"]
+      interval: 3s
+      timeout: 5s
+      retries: 10
+
+  graphql-engine:
+    build:
+      context: .
+      dockerfile: ./docker/api.dockerfile
+    ports:
+      - 3000:3000
+    depends_on:
+      "postgres":
+        condition: service_healthy
+      "subquery-node":
+        condition: service_started
+    restart: always
+    environment:
+      DB_USER: "subquery"
+      DB_PASS: "subquery"
+      DB_DATABASE: "subquery"
+      DB_HOST: postgres
+      DB_PORT: 5432
+    entrypoint: ["/sbin/tini", "--", "yarn", "start:prod"]
+    command:
+      - --name=app
+      - --playground
+      - --indexer=http://subquery-node:3000
+
+  fetch-node:
+    build:
+      context: .
+      dockerfile: ./docker/fetchd.dockerfile
+    environment:
+      FETCHMNEMONIC: "nut grocery slice visit barrel peanut tumble patch slim logic install evidence fiction shield rich brown around arrest fresh position animal butter forget cost"
+    ports:
+      - "26657:26657"
+      - "1317:1317"
+      - "9090:9090"

--- a/docker/fetchd.dockerfile
+++ b/docker/fetchd.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as base
+FROM fetchai/fetchd:0.10.6
 
 USER root
 
@@ -26,27 +26,6 @@ ENV TOKEN=${token}
 #ARG validator_key_pwd="12345678"
 #ENV VALIDATOR_KEY_PWD=${validator_key_pwd}
 ENV FETCHMNEMONIC="nut grocery slice visit barrel peanut tumble patch slim logic install evidence fiction shield rich brown around arrest fresh position animal butter forget cost"
-
-####################
-### dependencies ###
-####################
-
-
-# utils
-RUN apt-get update && apt-get install -y wget make curl git jq python3 python3-pip
-ENV LC_ALL C.UTF-8
-ENV LANG C.UTF-8
-
-# golang
-RUN wget https://golang.org/dl/go${GOLANG_VER}.linux-amd64.tar.gz && \
-    tar -xzvf go${GOLANG_VER}.linux-amd64.tar.gz -C /usr/local && \
-    mkdir /root/go
-ENV PATH="${PATH}:/usr/local/go/bin:/root/go/bin"
-
-# fetchd (https://docs.fetch.ai/ledger_v2/building/)
-RUN git clone https://github.com/fetchai/fetchd.git && cd fetchd && \
-    git checkout v${FETCHD_VER} && \
-    make install && fetchd version
 
 ########################
 ### setup local node ###


### PR DESCRIPTION
### Changes

- use pre-built fetchd base-image (faster)
- use CI-specific docker compose file
- ensure all node_modules directories are covered by dockerignore file
- add workflow to exercise end-to-end tests

### Dependencies

- [x] #74