### PR TITLE
chore: added support to update bridge contract address

### DIFF
--- a/scripts/node-entrypoint.sh
+++ b/scripts/node-entrypoint.sh
@@ -17,5 +17,10 @@ if [[ ! -z "${NETWORK_ENDPOINT}" ]]; then
     yq -i '.network.endpoint = strenv(NETWORK_ENDPOINT)' project.yaml
 fi
 
+if [[ ! -z "${LEGACY_BRIDGE_CONTRACT_ADDRESS}" ]]; then
+    echo "[Config Update] Legacy Bridge Contract Address: ${LEGACY_BRIDGE_CONTRACT_ADDRESS}"
+    yq -i '.dataSources[].mapping.handlers |= map(select(.handler == "handleLegacyBridgeSwap").filter.values.contract = env(LEGACY_BRIDGE_CONTRACT_ADDRESS))' project.yaml
+fi
+
 # run the main node
 exec /sbin/tini -- /usr/local/lib/node_modules/@subql/node-cosmos/bin/run


### PR DESCRIPTION
Issue: https://github.com/fetchai/ledger-subquery/issues/60

Details:
- Support to override legacy bridge contract address in `project.yaml`
- It can be overridden with an environment variable: `LEGACY_BRIDGE_CONTRACT_ADDRESS`
- The existing `node-entrypoint.sh` has been updated to override the contract address if the environment variable is provided variables.
