### PR TITLE
fix: added chainTypes in network

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -16,16 +16,16 @@ schema:
 network:
   chainId: dorado-1
   endpoint: https://rpc-dorado.fetch.ai:443
+  chainTypes: # This is a beta feature that allows support for any Cosmos chain by importing the correct protobuf messages
+    cosmos.slashing.v1beta1:
+      file: "./proto/cosmos/slashing/v1beta1/tx.proto"
+      messages:
+        - "MsgUnjail"
   # Using a dictionary can massively improve indexing speed
   dictionary: https://api.subquery.network/sq/subquery/cosmos-fetch-ai-dictionary
 dataSources:
   - kind: cosmos/Runtime
     startBlock: 827201
-    chainTypes: # This is a beta feature that allows support for any Cosmos chain by importing the correct protobuf messages
-      cosmos.slashing.v1beta1:
-        file: "./proto/cosmos/slashing/v1beta1/tx.proto"
-        messages:
-          - "MsgUnjail"
     mapping:
       file: "./dist/index.js"
       handlers:


### PR DESCRIPTION
Error:
```
ERROR Failed to decode message Error: Unregistered type url: /cosmos.slashing.v1beta1.MsgUnjail
2022-08-29T05:03:27.875Z <fetch> ERROR failed to index block at height 2590346 handleMessage() Error: Unregistered type url: /cosmos.slashing.v1beta1.MsgUnjail
```

Solution:
- move chainTypes to `network` section instead of `dataSources`
https://github.com/subquery/cosmos-subql-dictionaries/blob/main/project_fetchhub.yaml#L17