### PR TITLE
fix: api docker build github action

### DIFF
--- a/.github/workflows/docker_deploy_prod.yml
+++ b/.github/workflows/docker_deploy_prod.yml
@@ -57,7 +57,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: ./docker/node.dockerfile
+          file: ./docker/api.dockerfile
           push: true
           tags: |
             gcr.io/${{ env.IMAGE_PROJECT_ID }}/${{ env.API_IMAGE_NAME }}:${{ steps.vars.outputs.api_tag_name }}


### PR DESCRIPTION
- Updated GitHub action to use `api.dockerfile` to build graphql API dockerimage