### PR TITLE
chore: add message field to native transfer entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -109,12 +109,6 @@ type Coin @jsonField {
   amount: String!
 }
 
-type NativeTransferMsg @jsonField {
-  toAddress: String! @index
-  fromAddress: String! @index
-  amount: [Coin]! @index
-}
-
 type NativeTransfer @entity {
   id: ID!
   toAddress: String! @index

--- a/schema.graphql
+++ b/schema.graphql
@@ -115,6 +115,7 @@ type NativeTransfer @entity {
   fromAddress: String! @index
   amounts: [Coin]!
   denom: String! @index
+  message: Message!
   transaction: Transaction!
   block: Block!
 }

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -13,10 +13,10 @@ import {
 } from "../types";
 import {CosmosBlock, CosmosEvent, CosmosMessage, CosmosTransaction,} from "@subql/types-cosmos";
 import {
-    ExecuteContractMsg,
-    DistDelegatorClaimMsg,
-    GovProposalVoteMsg,
-    LegacyBridgeSwapMsg
+  ExecuteContractMsg,
+  DistDelegatorClaimMsg,
+  GovProposalVoteMsg,
+  LegacyBridgeSwapMsg,
   NativeTransferMsg
 } from "./types";
 import {SignerInfo} from "cosmjs-types/cosmos/tx/v1beta1/tx";

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -98,12 +98,14 @@ export async function handleNativeTransfer(msg: CosmosMessage<NativeTransferMsg>
   const {toAddress, fromAddress, amount: amounts} = msg.msg.decodedMsg;
   // workaround: assuming one denomination per transfer message
   const denom = amounts[0].denom;
+  const id = messageId(msg);
   const transferEntity = NativeTransfer.create({
-    id: messageId(msg),
+    id,
     toAddress,
     fromAddress,
     amounts,
     denom,
+    messageId: id,
     transactionId: msg.tx.hash,
     blockId: msg.block.block.id
   });

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -8,7 +8,6 @@ import {
   LegacyBridgeSwap,
   Message,
   NativeTransfer,
-  NativeTransferMsg,
   Transaction,
   TxStatus
 } from "../types";
@@ -18,6 +17,7 @@ import {
     DistDelegatorClaimMsg,
     GovProposalVoteMsg,
     LegacyBridgeSwapMsg
+  NativeTransferMsg
 } from "./types";
 import {SignerInfo} from "cosmjs-types/cosmos/tx/v1beta1/tx";
 import {toBech32} from "@cosmjs/encoding";

--- a/src/mappings/types/messages.ts
+++ b/src/mappings/types/messages.ts
@@ -1,5 +1,11 @@
 import {Coin} from "./common";
 
+export interface NativeTransferMsg {
+  toAddress: string;
+  fromAddress: string;
+  amount: Coin[];
+}
+
 export interface ExecuteContractMsg {
   contract: string;
   msg: object;

--- a/test/helpers/graphql.py
+++ b/test/helpers/graphql.py
@@ -1,0 +1,23 @@
+import json
+import re
+
+from gql import gql
+
+json_keys_regex = re.compile('"(\w+)":')
+
+
+def to_gql(obj):
+    # NB: strip quotes from object keys
+    return json_keys_regex.sub("\g<1>:", json.dumps(obj))
+
+
+def test_filtered_query(root_entity, _filter, nodes_string):
+    filter_string = to_gql(_filter)
+
+    return gql("""
+    query {
+        """ + root_entity + """ (filter: """ + filter_string + """) {
+            nodes """ + nodes_string + """
+        }
+    }
+    """)

--- a/test/test_native_transfer.py
+++ b/test/test_native_transfer.py
@@ -105,6 +105,7 @@ class TestNativeTransfer(base.Base):
                 native_transfers = result["nativeTransfers"]["nodes"]
                 self.assertNotEqual(native_transfers, [], "\nGQLError: No results returned from query")
                 self.assertRegex(native_transfers[0]["id"], msg_id_regex)
+                self.assertRegex(native_transfers[0]["message"]["id"], msg_id_regex)
                 self.assertRegex(native_transfers[0]["transaction"]["id"], tx_id_regex)
                 self.assertRegex(native_transfers[0]["block"]["id"], block_id_regex)
                 # NB: `amount` is a list of `Coin`s (i.e. [{amount: "", denom: ""}, ...])

--- a/test/test_native_transfer.py
+++ b/test/test_native_transfer.py
@@ -7,6 +7,8 @@ import unittest
 from gql import gql
 
 from helpers.field_enums import NativeTransferFields
+from helpers.graphql import test_filtered_query
+from helpers.regexes import msg_id_regex, block_id_regex, tx_id_regex
 
 
 class TestNativeTransfer(base.Base):
@@ -34,110 +36,83 @@ class TestNativeTransfer(base.Base):
         self.assertEqual(native_transfer[NativeTransferFields.to_address.value], self.delegator_address, "\nDBError: swap sender address does not match")
         self.assertEqual(native_transfer[NativeTransferFields.from_address.value], self.validator_address, "\nDBError: sender address does not match")
 
-    def test_retrieve_transfer(self):  # As of now, this test depends on the execution of the previous test in this class.
+    def test_retrieve_transfer(self):
         result = self.get_latest_block_timestamp()
-        time_before = result - dt.timedelta(minutes=5)  # create a second timestamp for five minutes before
-        time_before = json.dumps(time_before.isoformat())  # convert both to JSON ISO format
-        time_latest = json.dumps(result.isoformat())
+        # create a second timestamp for five minutes before
+        min_timestamp = (result - dt.timedelta(minutes=5)).isoformat()  # convert both to JSON ISO format
+        max_timestamp = result.isoformat()
+
+        native_transfer_nodes = """
+            {
+                id,
+                message { id }
+                transaction { id }
+                block { id }
+                amounts
+                denom
+                toAddress
+                fromAddress
+            }
+            """
+
+        def filtered_native_transaction_query(_filter):
+            return test_filtered_query("nativeTransfers", _filter, native_transfer_nodes)
 
         # query native transactions, query related block and filter by timestamp, returning all within last five minutes
-        query_get_by_range = gql(
-            """
-            query getByRange {
-                nativeTransfers (
-                filter: {
-                    block: {
-                    timestamp: {
-                        greaterThanOrEqualTo: """ + time_before + """,
-                        lessThanOrEqualTo: """ + time_latest + """
-                        }
-                    }
-                }) {
-                nodes {
-                    denom
-                    toAddress
-                    fromAddress
-                    }
+        filter_by_block_timestamp_range = filtered_native_transaction_query({
+            "block": {
+                "timestamp": {
+                    "greaterThanOrEqualTo": min_timestamp,
+                    "lessThanOrEqualTo": max_timestamp
                 }
             }
-            """
-        )
+        })
 
         # query native transactions, filter by recipient address
-        query_get_by_to_address = gql(
-            """
-            query getByToAddress {
-                nativeTransfers (
-                filter: {
-                    toAddress: {
-                        equalTo: """+json.dumps(self.delegator_address)+"""
-                        }
-                    }
-                ) {
-                nodes {
-                    denom
-                    toAddress
-                    fromAddress
-                    }
-                }
+        filter_by_to_address_equals = filtered_native_transaction_query({
+            "toAddress": {
+                "equalTo": self.delegator_address
             }
-            """
-        )
+        })
 
         # query native transactions, filter by sender address
-        query_get_by_from_address = gql(
-            """
-            query getByFromAddress {
-                nativeTransfers (
-                filter: {
-                    fromAddress: {
-                        equalTo: """+json.dumps(self.validator_address)+"""
-                        }
-                    }
-                ) {
-                nodes {
-                    denom
-                    toAddress
-                    fromAddress
-                    }
-                }
+        filter_by_from_address_equals = filtered_native_transaction_query({
+            "fromAddress": {
+                "equalTo": self.validator_address
             }
-            """
-        )
+        })
 
         # query native transactions, filter by denomination
-        query_get_by_denom = gql(
-            """
-            query getByDenom {
-                nativeTransfers (
-                filter: {
-                    denom: {
-                        equalTo:\""""+self.denom+"""\"
-                    }
-                }) {
-                    nodes {
-                        denom
-                        toAddress
-                        fromAddress
-                    }
-                }
+        filter_by_denom_equals = filtered_native_transaction_query({
+            "denom": {
+                "equalTo": self.denom
             }
-            """
-        )
+        })
 
-        queries = [query_get_by_range, query_get_by_to_address, query_get_by_from_address, query_get_by_denom]
-        for query in queries:
-            result = self.gql_client.execute(query)
-            """
-            ["nativeTransfers"]["nodes"][0] denotes the sequence of keys to access the message contents queried for above.
-            This provides {"toAddress":address, "fromAddress":address, "denom":denom, "amount":["amount":amount, "denom":denom]}
-            which can be destructured for the values of interest.
-            """
-            native_transfers = result["nativeTransfers"]["nodes"]
-            self.assertNotEqual(native_transfers, [], "\nGQLError: No results returned from query")
-            self.assertEqual(native_transfers[0]["denom"], self.denom, "\nGQLError: fund denomination does not match")
-            self.assertEqual(native_transfers[0]["toAddress"], self.delegator_address, "\nGQLError: destination address does not match")
-            self.assertEqual(native_transfers[0]["fromAddress"], self.validator_address, "\nGQLError: from address does not match")
+        for (name, query) in [
+            ("by block timestamp range", filter_by_block_timestamp_range),
+            ("by toAddress equals", filter_by_to_address_equals),
+            ("by fromAddress equals", filter_by_from_address_equals),
+            ("by denom equals", filter_by_denom_equals)
+        ]:
+            with self.subTest(name):
+                result = self.gql_client.execute(query)
+                """
+                ["nativeTransfers"]["nodes"][0] denotes the sequence of keys to access the message contents queried for above.
+                This provides {"toAddress":address, "fromAddress":address, "denom":denom, "amount":["amount":amount, "denom":denom]}
+                which can be destructured for the values of interest.
+                """
+                native_transfers = result["nativeTransfers"]["nodes"]
+                self.assertNotEqual(native_transfers, [], "\nGQLError: No results returned from query")
+                self.assertRegex(native_transfers[0]["id"], msg_id_regex)
+                self.assertRegex(native_transfers[0]["transaction"]["id"], tx_id_regex)
+                self.assertRegex(native_transfers[0]["block"]["id"], block_id_regex)
+                # NB: `amount` is a list of `Coin`s (i.e. [{amount: "", denom: ""}, ...])
+                self.assertEqual(int(native_transfers[0]["amounts"][0]["amount"]), self.amount, "\nGQLError: fund amount does not match")
+                self.assertEqual(native_transfers[0]["amounts"][0]["denom"], self.denom, "\nGQLError: fund denom does not match")
+                self.assertEqual(native_transfers[0]["denom"], self.denom, "\nGQLError: fund denomination does not match")
+                self.assertEqual(native_transfers[0]["toAddress"], self.delegator_address, "\nGQLError: destination address does not match")
+                self.assertEqual(native_transfers[0]["fromAddress"], self.validator_address, "\nGQLError: from address does not match")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Changes
- replace gql schema type with vanilla TypeScript type (not necessary to be a gql schema type)
- refactor native transfer gql queries
- add message field to the native transfer entity