### PR TITLE
fix: devops bits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     image: postgres:14-alpine
     ports:
       - 5432:5432
-    volumes:
-      - .data/postgres:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: "subquery"
       POSTGRES_PASSWORD: "subquery"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       START_BLOCK: "1"
       NETWORK_ENDPOINT: "http://fetch-node:26657"
       CHAIN_ID: "testing"
+      LEGACY_BRIDGE_CONTRACT_ADDRESS: "fetch14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9szlkpka"
     volumes:
       - ./:/app
     command:

--- a/project.yaml
+++ b/project.yaml
@@ -56,7 +56,7 @@ dataSources:
             # Filter to only messages with the vote function call
             contractCall: "swap" # The name of the contract function that was called
             values: # This is the specific smart contract that we are subscribing to
-              contract: "fetch1qxxlalvsdjd07p07y3rc5fu6ll8k4tmetpha8n"
+              contract: "fetch1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrsa26575"
         - handler: handleNativeTransfer
           kind: cosmos/MessageHandler
           filter:


### PR DESCRIPTION
### Changes
- remove postgres data volume from docker-compose by default 
  - improves TDD workflow
  - can be added via docker-compose.override.yml
-  add `LEGACY_BRIDGE_CONTRACT_ADDRESS` in docker-compose to match contract with code 0
- update legacy bridge contract address in project.yaml to the testnet bridge (fetch-side) contract address
  - docker-compose.yml defaults to testnet config