### PR TITLE
fix: bridge contract remove hardcoded address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,6 @@ services:
       START_BLOCK: "1"
       NETWORK_ENDPOINT: "http://fetch-node:26657"
       CHAIN_ID: "testing"
-      LEGACY_BRIDGE_CONTRACT_ADDRESS: "fetch14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9szlkpka"
     volumes:
       - ./:/app
     command:

--- a/project.yaml
+++ b/project.yaml
@@ -53,10 +53,8 @@ dataSources:
           kind: cosmos/MessageHandler
           filter:
             type: "/cosmwasm.wasm.v1.MsgExecuteContract"
-            # Filter to only messages with the vote function call
+            # Filter to only messages with the swap function call
             contractCall: "swap" # The name of the contract function that was called
-            values: # This is the specific smart contract that we are subscribing to
-              contract: "fetch1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrsa26575"
         - handler: handleNativeTransfer
           kind: cosmos/MessageHandler
           filter:

--- a/schema.graphql
+++ b/schema.graphql
@@ -97,6 +97,7 @@ type DistDelegatorClaim @entity {
 type LegacyBridgeSwap @entity {
   id: ID! # id field is always required and must look like this
   destination: String!
+  contract: String!
   amount: BigInt!
   denom: String!
   executeContractMessage: ExecuteContractMessage!

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -219,11 +219,13 @@ export async function handleLegacyBridgeSwap(msg: CosmosMessage<LegacyBridgeSwap
   const id = messageId(msg);
   const {
     msg: {swap: {destination}},
-    funds: [{amount, denom}]
+    funds: [{amount, denom}],
+    contract,
   } = msg.msg.decodedMsg;
   const legacySwap = LegacyBridgeSwap.create({
     id,
     destination,
+    contract,
     amount: BigInt(amount),
     denom,
     executeContractMessageId: id,

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -213,15 +213,23 @@ export async function handleDistDelegatorClaim(msg: CosmosMessage<DistDelegatorC
 }
 
 export async function handleLegacyBridgeSwap(msg: CosmosMessage<LegacyBridgeSwapMsg>): Promise<void> {
-  logger.info(`[handleLegacyBridgeSwap] (tx ${msg.tx.hash}): indexing LegacyBridgeSwap ${messageId(msg)}`)
+  const id = messageId(msg);
+  logger.info(`[handleLegacyBridgeSwap] (tx ${msg.tx.hash}): indexing LegacyBridgeSwap ${id}`)
   logger.debug(`[handleLegacyBridgeSwap] (msg.msg): ${JSON.stringify(msg.msg, null, 2)}`)
 
-  const id = messageId(msg);
   const {
     msg: {swap: {destination}},
     funds: [{amount, denom}],
     contract,
   } = msg.msg.decodedMsg;
+  
+  // gracefully skip indexing "swap" messages that doesn't fullfill the bridge contract
+  // otherwise, the node will just crashloop trying to save the message to the db with required null fields.
+  if (!destination || !amount || !denom || !contract) {
+    logger.warn(`[handleLegacyBridgeSwap] (tx ${msg.tx.hash}): cannot index message (msg.msg): ${JSON.stringify(msg.msg, null, 2)}`)
+    return 
+  }
+  
   const legacySwap = LegacyBridgeSwap.create({
     id,
     destination,

--- a/test/base_contract.py
+++ b/test/base_contract.py
@@ -2,12 +2,12 @@ import unittest, base, requests, os
 from cosmpy.aerial.contract import LedgerContract
 
 
-class BaseContract(base.Base):
+class BridgeContract(base.Base):
     contract = None
 
     @classmethod
     def setUpClass(cls):
-        super(BaseContract, cls).setUpClass()
+        super(BridgeContract, cls).setUpClass()
         url = "https://github.com/fetchai/fetch-ethereum-bridge-v1/releases/download/v0.2.0/bridge.wasm"
         if not os.path.exists("../.contract"):
             os.mkdir("../.contract")
@@ -17,23 +17,27 @@ class BaseContract(base.Base):
         except:
             contract_request = requests.get(url)
             file = open("../.contract/bridge.wasm", "wb").write(contract_request.content)
+            file.close()
 
+        # LedgerContract will attempt to discover any existing contract having the same bytecode hash
+        # see https://github.com/fetchai/cosmpy/blob/master/cosmpy/aerial/contract/__init__.py#L74
         cls.contract = LedgerContract("../.contract/bridge.wasm", cls.ledger_client)
-
-        # TODO: avoid deploying with every test run
-        # Instead, query for active contract and skip if found.
-
+        
+        # deploy will store the contract only if no existing contracts was found during init.
+        # and it will instantiate the contract only if contract.address is None
+        # see: https://github.com/fetchai/cosmpy/blob/master/cosmpy/aerial/contract/__init__.py#L168-L179
         cls.contract.deploy(
-            {"cap": "250000000000000000000000000",
-             "reverse_aggregated_allowance": "3000000000000000000000000",
-             "reverse_aggregated_allowance_approver_cap": "3000000000000000000000000",
-             "lower_swap_limit": "1",
-             "upper_swap_limit": "1000000000000000000000000",
-             "swap_fee": "0",
-             "paused_since_block": 18446744073709551615,
-             "denom": "atestfet",
-             "next_swap_id": 0
-             },
+            {
+                "cap": "250000000000000000000000000",
+                "reverse_aggregated_allowance": "3000000000000000000000000",
+                "reverse_aggregated_allowance_approver_cap": "3000000000000000000000000",
+                "lower_swap_limit": "1",
+                "upper_swap_limit": "1000000000000000000000000",
+                "swap_fee": "0",
+                "paused_since_block": 18446744073709551615,
+                "denom": "atestfet",
+                "next_swap_id": 0
+            },
             cls.validator_wallet
         )
 

--- a/test/base_contract.py
+++ b/test/base_contract.py
@@ -16,7 +16,8 @@ class BridgeContract(base.Base):
             temp.close()
         except:
             contract_request = requests.get(url)
-            file = open("../.contract/bridge.wasm", "wb").write(contract_request.content)
+            file = open("../.contract/bridge.wasm", "wb")
+            file.write(contract_request.content)
             file.close()
 
         # LedgerContract will attempt to discover any existing contract having the same bytecode hash

--- a/test/helpers/field_enums.py
+++ b/test/helpers/field_enums.py
@@ -83,6 +83,7 @@ class LegacyBridgeSwapFields(NamedFields):
     destination = 4
     amount = 5
     denom = 6
+    contract = 7
 
     @classmethod
     def select_query(cls, table="legacy_bridge_swaps"):

--- a/test/test_execute_contract_message.py
+++ b/test/test_execute_contract_message.py
@@ -5,11 +5,11 @@ import unittest
 
 from gql import gql
 
-from base_contract import BaseContract
+from base_contract import BridgeContract
 from helpers.field_enums import ExecuteContractMessageFields
 
 
-class TestContractExecution(BaseContract):
+class TestContractExecution(BridgeContract):
     amount = '10000'
     denom = "atestfet"
     method = 'swap'

--- a/test/test_legacy_bridge_swap.py
+++ b/test/test_legacy_bridge_swap.py
@@ -1,19 +1,13 @@
 import datetime as dt
 import decimal
-import json
-import re
-import time
 import unittest
+import time
 
-from gql import gql
-
-from base_contract import BaseContract
+from base_contract import BridgeContract
 from helpers.field_enums import LegacyBridgeSwapFields
 from helpers.graphql import test_filtered_query
-from helpers.regexes import msg_id_regex, tx_id_regex, block_id_regex
 
-
-class TestContractSwap(BaseContract):
+class TestContractSwap(BridgeContract):
     amount = decimal.Decimal(10000)
     denom = "atestfet"
 
@@ -22,19 +16,19 @@ class TestContractSwap(BaseContract):
         super().setUpClass()
         cls.clean_db({"legacy_bridge_swaps"})
 
-        cls.contract.execute(
+        resp = cls.contract.execute(
             {"swap": {"destination": cls.validator_address}},
             cls.validator_wallet,
             funds=str(cls.amount)+cls.denom
         )
-
-        # primitive solution to wait for indexer to observe and handle new tx - TODO: add robust solution
-        time.sleep(12)
+        cls.ledger_client.wait_for_query_tx(resp.tx_hash)
+        time.sleep(5) # stil need to give some extra time for the indexer to pickup the tx
 
     def test_contract_swap(self):
         swap = self.db_cursor.execute(LegacyBridgeSwapFields.select_query()).fetchone()
         self.assertIsNotNone(swap, "\nDBError: table is empty - maybe indexer did not find an entry?")
         self.assertEqual(swap[LegacyBridgeSwapFields.destination.value], self.validator_address, "\nDBError: swap sender address does not match")
+        self.assertEqual(swap[LegacyBridgeSwapFields.contract.value], self.contract.address, "\nDBError: contract address does not match")
         self.assertEqual(swap[LegacyBridgeSwapFields.amount.value], self.amount, "\nDBError: fund amount does not match")
         self.assertEqual(swap[LegacyBridgeSwapFields.denom.value], self.denom, "\nDBError: fund denomination does not match")
 
@@ -48,6 +42,7 @@ class TestContractSwap(BaseContract):
             {
                 id
                 destination
+                contract
                 amount
                 denom
                 executeContractMessage { id }
@@ -74,6 +69,13 @@ class TestContractSwap(BaseContract):
         filter_by_destination_equals = filtered_legacy_bridge_swap_query({
             "destination": {
                 "equalTo": str(self.validator_address)
+            }
+        })
+        
+        # query bridge swaps, filter by contract address
+        filter_by_destination_equals = filtered_legacy_bridge_swap_query({
+            "contract": {
+                "equalTo": str(self.contract.address)
             }
         })
 

--- a/test/test_legacy_bridge_swap.py
+++ b/test/test_legacy_bridge_swap.py
@@ -73,7 +73,7 @@ class TestContractSwap(BridgeContract):
         })
         
         # query bridge swaps, filter by contract address
-        filter_by_destination_equals = filtered_legacy_bridge_swap_query({
+        filter_by_contract_equals = filtered_legacy_bridge_swap_query({
             "contract": {
                 "equalTo": str(self.contract.address)
             }
@@ -89,7 +89,8 @@ class TestContractSwap(BridgeContract):
         for (name, query) in [
             ("by block timestamp range", filter_by_block_timestamp_range),
             ("by amount above", filter_by_amount_above),
-            ("by destination equals", filter_by_destination_equals)
+            ("by destination equals", filter_by_destination_equals),
+            ("by contract equals", filter_by_contract_equals),
         ]:
             with self.subTest(name):
                 result = self.gql_client.execute(query)


### PR DESCRIPTION
- Remove the hardcoded address on the handleLegacyBridgeSwap, as this address is dependant on the number of previously stored / instantiated contracts
- Instead extract the contract address from the swap tx, which should still allow querying all swaps for a particular contract
- rename `BaseContract` to `BridgeContract`, in anticipation of supporting other kinds of contracts (ie: CW20)
- reduced sleep time in `TestContractSwap` to wait only for indexer to pickup the messages, it now wait for the swap tx using cosmpy `wait_for_query_tx()`