### PR TITLE
fix: parseCoins

### DIFF
--- a/src/mappings/utils.ts
+++ b/src/mappings/utils.ts
@@ -3,7 +3,6 @@
  */
 
 import { Coin } from "@cosmjs/amino";
-import { Uint64 } from "@cosmjs/math";
 
 /**
  * Takes a coins list like "819966000ucosm,700000000ustake" and parses it.

--- a/src/mappings/utils.ts
+++ b/src/mappings/utils.ts
@@ -21,7 +21,7 @@ export function parseCoins(input: string): Coin[] {
       const match = part.match(/^([0-9]+)([a-zA-Z][a-zA-Z0-9/]{2,127})$/);
       if (!match) throw new Error("Got an invalid coin string");
       return {
-        amount: Uint64.fromString(match[1]).toString(),
+        amount: match[1].toString(),
         denom: match[2],
       };
     });


### PR DESCRIPTION
### Changes

- fixes an error:

```
 2022-09-01T13:16:35.435Z <fetch> INFO fetch block [839146,839245], total 100 blocks
 2022-09-01T13:16:35.523Z <fetch> ERROR failed to index block at height 839046 handleDelegatorWithdrawRewardEvent() Error: Input exceeds uint64 range

```