### PR TITLE
fix: remove LEGACY_BRIDGE_CONTRACT_ADDRESS from node-entrypoint.sh

### DIFF
--- a/scripts/node-entrypoint.sh
+++ b/scripts/node-entrypoint.sh
@@ -17,10 +17,5 @@ if [[ ! -z "${NETWORK_ENDPOINT}" ]]; then
     yq -i '.network.endpoint = strenv(NETWORK_ENDPOINT)' project.yaml
 fi
 
-if [[ ! -z "${LEGACY_BRIDGE_CONTRACT_ADDRESS}" ]]; then
-    echo "[Config Update] Legacy Bridge Contract Address: ${LEGACY_BRIDGE_CONTRACT_ADDRESS}"
-    yq -i '.dataSources[].mapping.handlers |= map(select(.handler == "handleLegacyBridgeSwap").filter.values.contract = env(LEGACY_BRIDGE_CONTRACT_ADDRESS))' project.yaml
-fi
-
 # run the main node
 exec /sbin/tini -- /usr/local/lib/node_modules/@subql/node-cosmos/bin/run


### PR DESCRIPTION
### Background

As of #70, we're generalizing contract instances, subsequently, this part of the project.yaml modification is no longer necessary.