### PR TITLE
feat: account balance tracking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       "postgres":
         condition: service_healthy
       "subquery-node":
-        condition: service_started
+        condition: service_healthy
     restart: always
     environment:
       DB_USER: "subquery"

--- a/project.yaml
+++ b/project.yaml
@@ -63,3 +63,11 @@ dataSources:
           kind: cosmos/EventHandler
           filter:
             type: "withdraw_rewards"
+        - handler: handleNativeBalanceDecrement
+          kind: cosmos/EventHandler
+          filter:
+            type: "coin_spent"
+        - handler: handleNativeBalanceIncrement
+          kind: cosmos/EventHandler
+          filter:
+            type: "coin_received"

--- a/schema.graphql
+++ b/schema.graphql
@@ -121,3 +121,17 @@ type NativeTransfer @entity {
   transaction: Transaction!
   block: Block!
 }
+
+type Account @entity {
+  # id is the address
+  id: ID!
+  nativeBalances: [NativeBalance]! @derivedFrom(field: "account")
+}
+
+type NativeBalance @entity {
+  id: ID!
+  genesisBalance: BigInt!
+  balanceOffset: BigInt!
+  denom: String!
+  account: Account!
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -130,8 +130,8 @@ type Account @entity {
 
 type NativeBalance @entity {
   id: ID!
-  genesisBalance: BigInt!
   balanceOffset: BigInt!
   denom: String!
   account: Account!
+  event: Event!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -125,13 +125,15 @@ type NativeTransfer @entity {
 type Account @entity {
   # id is the address
   id: ID!
-  nativeBalances: [NativeBalance]! @derivedFrom(field: "account")
+  nativeBalanceChanges: [NativeBalanceChange]! @derivedFrom(field: "account")
 }
 
-type NativeBalance @entity {
+type NativeBalanceChange @entity {
   id: ID!
   balanceOffset: BigInt!
-  denom: String!
+  denom: String! @index
   account: Account!
   event: Event!
+  transaction: Transaction!
+  block: Block!
 }

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -1,6 +1,6 @@
 import {
   Account,
-  NativeBalance,
+  NativeBalanceChange,
   Block,
   DistDelegatorClaim,
   Event,
@@ -354,13 +354,15 @@ async function saveNativeBalanceEvent(id: string, address: string, amount: BigIn
     await accountEntity.save();
   }
 
-  const nativeBalanceEntity = NativeBalance.create({
+  const nativeBalanceChangeEntity = NativeBalanceChange.create({
     id,
     accountId: address,
     balanceOffset: amount.valueOf(),
     denom: denom,
     eventId: `${messageId(event)}-${event.idx}`,
+    blockId: event.block.block.id,
+    transactionId: event.tx.hash,
   });
 
-  await nativeBalanceEntity.save()
+  await nativeBalanceChangeEntity.save()
 }

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -300,20 +300,19 @@ export async function handleNativeBalanceDecrement(event: CosmosEvent): Promise<
   //   {"key":"amount","value":"100atestfet"}
   // ]
   let spendEvents = [];
-  event.event.attributes.map((e, i) => {
+  for (const [i, e] of Object.entries(event.event.attributes)) {
     if (e.key !== "spender") {
-      return
+      continue
     }
     const spender = e.value;
-    const amountStr = event.event.attributes[i+1].value;
+    const amountStr = event.event.attributes[parseInt(i)+1].value;
 
     const coin = parseCoins(amountStr)[0];
     const amount = BigInt(0) - BigInt(coin.amount); // save a negative amount for a "spend" event
     spendEvents.push({spender: spender, amount: amount, denom: coin.denom})
-  });
+  };
   
-  for (const i in spendEvents) {
-    const spendEvent = spendEvents[i];
+  for (const [i, spendEvent] of Object.entries(spendEvents)) {
     await saveNativeBalanceEvent(`${messageId(event)}-spend-${i}`, spendEvent.spender, spendEvent.amount, spendEvent.denom, event);
   }
 }
@@ -331,20 +330,19 @@ export async function handleNativeBalanceIncrement(event: CosmosEvent): Promise<
   //   {"key":"amount","value":"100atestfet"}
   // ]
   let receiveEvents = [];
-  event.event.attributes.map((e, i) => {
+  for (const [i, e] of Object.entries(event.event.attributes)) {
     if (e.key !== "receiver") {
-      return
+      continue
     }
     const receiver = e.value;
-    const amountStr = event.event.attributes[i+1].value;
+    const amountStr = event.event.attributes[parseInt(i)+1].value;
 
     const coin = parseCoins(amountStr)[0];
     const amount = BigInt(coin.amount);
     receiveEvents.push({receiver: receiver, amount: amount, denom: coin.denom})
-  });
+  };
   
-  for (const i in receiveEvents) {
-    const receiveEvent = receiveEvents[i];
+  for (const [i, receiveEvent] of Object.entries(receiveEvents)) {
     await saveNativeBalanceEvent(`${messageId(event)}-receive-${i}`, receiveEvent.receiver, receiveEvent.amount, receiveEvent.denom, event);
   }
 }

--- a/test/helpers/field_enums.py
+++ b/test/helpers/field_enums.py
@@ -130,3 +130,9 @@ class DistDelegatorClaimFields(NamedFields):
     @classmethod
     def select_query(cls, table="dist_delegator_claims"):
         return super().select_query(table)
+
+class NativeBalanceFields(NamedFields):
+    id = 0
+    address = 1
+    amount = 1
+    denom = 2

--- a/test/helpers/field_enums.py
+++ b/test/helpers/field_enums.py
@@ -131,13 +131,15 @@ class DistDelegatorClaimFields(NamedFields):
     def select_query(cls, table="dist_delegator_claims"):
         return super().select_query(table)
 
-class NativeBalanceFields(NamedFields):
+class NativeBalanceChangeFields(NamedFields):
     id = 0
     balance_offset = 1
     denom = 2
     account_id = 3
     event_id = 4
-
+    transaction_id = 5
+    block_id = 6
+    
     @classmethod
-    def select_query(cls, table="native_balances"):
+    def select_query(cls, table="native_balance_changes"):
         return super().select_query(table)

--- a/test/helpers/field_enums.py
+++ b/test/helpers/field_enums.py
@@ -133,6 +133,11 @@ class DistDelegatorClaimFields(NamedFields):
 
 class NativeBalanceFields(NamedFields):
     id = 0
-    address = 1
-    amount = 1
+    balance_offset = 1
     denom = 2
+    account_id = 3
+    event_id = 4
+
+    @classmethod
+    def select_query(cls, table="native_balances"):
+        return super().select_query(table)

--- a/test/helpers/regexes.py
+++ b/test/helpers/regexes.py
@@ -4,4 +4,3 @@ block_id_regex = re.compile("^\w{64}$")
 tx_id_regex = block_id_regex
 msg_id_regex = re.compile("^\w{64}-\d+$")
 event_id_regex = re.compile("^\w{64}-\d+-\d+$")
-native_addr_id_regex = re.compile("^fetch\w{64}-\d+-\d+$")

--- a/test/test_native_balances.py
+++ b/test/test_native_balances.py
@@ -1,0 +1,43 @@
+import time
+
+import base
+from helpers.field_enums import NativeBalanceFields
+from helpers.regexes import native_addr_id_regex, native_addr_regex
+
+
+class TestNativeBalances(base.Base):
+    amount = 5000000
+    denom = "atestfet"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.db_cursor.execute("TRUNCATE table account_balances")
+        cls.db.commit()
+
+        results = cls.db_cursor.execute("SELECT id FROM account_balances").fetchall()
+        if len(results) != 0:
+            raise Exception(f"truncation of table \"accounts\" failed, {len(results)} records remain")
+
+        tx = cls.ledger_client.send_tokens(cls.delegator_wallet.address(), cls.amount, cls.denom, cls.validator_wallet)
+        tx.wait_to_complete()
+        if not tx.response.is_successful():
+            raise Exception(f"first set-up tx failed")
+
+        tx = cls.ledger_client.send_tokens(cls.delegator_wallet.address(), cls.amount, cls.denom, cls.validator_wallet)
+        tx.wait_to_complete()
+        if not tx.response.is_successful():
+            raise Exception(f"second set-up tx failed")
+
+        # Wait for subql node to sync
+        time.sleep(5)
+
+    def test_account(self):
+        balances = self.db_cursor.execute(NativeBalanceFields.select_query()).fetchall()
+        self.assertGreater(len(balances), 0)
+
+        for balance in balances:
+            self.assertRegex(balance[NativeBalanceFields.id.value], native_addr_id_regex)
+            self.assertRegex(balance[NativeBalanceFields.address.value], native_addr_regex)
+            self.assertEqual(int(balance[NativeBalanceFields.amount]), self.amount)

--- a/test/test_native_balances.py
+++ b/test/test_native_balances.py
@@ -11,15 +11,13 @@ class TestNativeBalances(base.Base):
         super().setUpClass()
         cls.clean_db({"native_balances"})
 
-        tx = cls.ledger_client.send_tokens(cls.delegator_wallet.address(), 10000, "atestfet", cls.validator_wallet)
+        tx = cls.ledger_client.send_tokens(cls.delegator_wallet.address(), 10*10**18, "atestfet", cls.validator_wallet)
         tx.wait_to_complete()
-        if not tx.response.is_successful():
-            raise Exception(f"first set-up tx failed")
-
-        tx = cls.ledger_client.send_tokens(cls.validator_wallet.address(), 3000, "atestfet", cls.delegator_wallet)
+        cls.assertTrue(tx.response.is_successful(), "first set-up tx failed")
+        
+        tx = cls.ledger_client.send_tokens(cls.validator_wallet.address(), 3*10**18, "atestfet", cls.delegator_wallet)
         tx.wait_to_complete()
-        if not tx.response.is_successful():
-            raise Exception(f"second set-up tx failed")
+        cls.assertTrue(tx.response.is_successful(), "second set-up tx failed")
 
         # Wait for subql node to sync
         time.sleep(5)
@@ -43,8 +41,8 @@ class TestNativeBalances(base.Base):
             
             total[event[NativeBalanceFields.account_id.value]] += event[NativeBalanceFields.balance_offset.value]
 
-        self.assertEqual(total[self.validator_wallet.address()], -7000)
-        self.assertEqual(total[self.delegator_wallet.address()], 7000)
+        self.assertEqual(total[self.validator_wallet.address()], -7*10**18)
+        self.assertEqual(total[self.delegator_wallet.address()], 7*10**18)
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
From a rebased #54, reworked `handleNativeBalanceDecrement` and `handleNativeBalanceIncrement` to index individual `coin_received` and `coin_spent` events, allowing to query for all the "balance changed" events for a particular account, and a 3rd party to compute the total balance at any point. 

This approach mainly allows the creation of some external script parsing the genesis file and inserting `NativeBalance` rows for accounts with their initial balances.

It also avoids maintaining some "total" balance number as this could quickly become inconsistent on any indexer failures without a way to know it. The main idea is to keep the door open for any "reindexing" or "replaying" options in case of anythings going wrong.

This PR still needs a bunch of tests to be added on the graphql side of things but wanted to share the initial idea first.

Also worth noting that fee spendings are actually not tracked by `coin_spent`  events for some reason. I've asked on cosmos Discord to see if this is intended

