### PR TITLE
fix: delay argument

### DIFF
--- a/src/genesis/observers/__init__.py
+++ b/src/genesis/observers/__init__.py
@@ -38,7 +38,7 @@ def process_genesis(db_conn_factory):
                           on_error=on_error,
                           on_completed=lambda: balances_done.release()).observe(genesis.source,
                                                                                 scheduler=scheduler,
-                                                                                delay=True)
+                                                                                delay=3)
 
     accounts_done.acquire()
     balances_done.acquire()


### PR DESCRIPTION
### Changes

Fixes the delay argument that is passed to `BalanceObserver#observe`. The method signature was recently changed and my IDE was too borked to notice the type hint violation.