### PR TITLE
chore: rename NativeBalance table to GenesisBalance

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -139,10 +139,10 @@ type Account @entity {
   chainId: String! @index
   nativeBalanceChanges: [NativeBalanceChange]! @derivedFrom(field: "account")
   cw20BalanceChanges: [Cw20BalanceChange]! @derivedFrom(field: "account")
-  genesisNativeBalances: [NativeBalance] @derivedFrom(field: "account")
+  genesisBalances: [GenesisBalance] @derivedFrom(field: "account")
 }
 
-type NativeBalance @entity {
+type GenesisBalance @entity {
     id: ID!
     amount: BigInt!
     denom: String! @index

--- a/src/genesis/observers/balances.py
+++ b/src/genesis/observers/balances.py
@@ -43,7 +43,7 @@ class NativeBalancesManager(TableManager):
     _observer: NativeBalancesObserver
     _subscription: DisposableBase
     _db_conn: Connection
-    _table = "native_balances"
+    _table = "genesis_balances"
     _columns = (
         ("id", DBTypes.text),
         ("account_id", DBTypes.text),


### PR DESCRIPTION
### Changes

- renames `NativeBalance` entity (`native_balances` table) to `GenesisBalance` (`genesis_balances`) for clarity
- rename `Account#nativeBalances` field to `Account#genesisBalances`