### PR TITLE
fix: swaps handler undefined checking

### DIFF
--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -308,11 +308,13 @@ export async function handleLegacyBridgeSwap(msg: CosmosMessage<LegacyBridgeSwap
   logger.info(`[handleLegacyBridgeSwap] (tx ${msg.tx.hash}): indexing LegacyBridgeSwap ${id}`)
   logger.debug(`[handleLegacyBridgeSwap] (msg.msg): ${JSON.stringify(msg.msg, null, 2)}`)
 
-  const {
-    msg: {swap: {destination}},
-    funds: [{amount, denom}],
-    contract,
-  } = msg.msg.decodedMsg;
+  const contract = msg.msg.decodedMsg.contract;
+  const swapMsg = msg.msg.decodedMsg.msg;
+  const destination = swapMsg?.swap?.destination;
+
+  const funds = msg.msg.decodedMsg.funds || [];
+  const amount = funds[0]?.amount;
+  const denom = funds[0]?.denom;
 
   // gracefully skip indexing "swap" messages that doesn't fullfill the bridge contract
   // otherwise, the node will just crashloop trying to save the message to the db with required null fields.


### PR DESCRIPTION
### Changes

Replace destructuring assignment with regular variable assignment using the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) to simplify checking for undefined values.