### PR TITLE
fix: forward script arguments to subquery CLI

### DIFF
--- a/scripts/node-entrypoint.sh
+++ b/scripts/node-entrypoint.sh
@@ -18,4 +18,4 @@ if [[ ! -z "${NETWORK_ENDPOINT}" ]]; then
 fi
 
 # run the main node
-exec /sbin/tini -- /usr/local/lib/node_modules/@subql/node-cosmos/bin/run
+exec /sbin/tini -- /usr/local/lib/node_modules/@subql/node-cosmos/bin/run "$@"


### PR DESCRIPTION
## Changes
- forward script arguments to SubQuery CLI

_Previously, any command arguments were actually being ignored (e.g. [docker-compose:39](https://github.com/fetchai/ledger-subquery/blob/main/docker-compose.yml#L39), [node.sts.yml:27](https://github.com/fetchai/ledger-subquery/blob/main/k8s/subquery/templates/name/node.sts.yml#L27))._