### PR TITLE
chore: add lint:fix yarn script to fix linter simple errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "lint": "yarn eslint ./src",
+    "lint:fix": "yarn eslint --fix ./src",
     "build": "subql build",
     "prepack": "rm -rf dist && npm build",
     "test": "jest",


### PR DESCRIPTION
## Changes

Adds `yarn lint:fix` to fix simple TypeScript linting errors.