### PR TITLE
chore: improve warning formatting in saveContractEvent helper

### DIFF
--- a/src/mappings/wasm/contracts.ts
+++ b/src/mappings/wasm/contracts.ts
@@ -106,7 +106,9 @@ async function saveContractEvent(instantiateMsg: InstantiateContractMessage, con
   const storeCodeMsg = (await StoreContractMessage.getByCodeId(instantiateMsg.codeId))[0];
 
   if (!storeCodeMsg || !contract_address || !instantiateMsg) {
-    logger.warn(`[saveContractEvent] (tx ${event.tx.hash}): failed to save contract (storeCodeMsg, instantiateMsg): ${storeCodeMsg}, ${instantiateMsg}`);
+    logger.warn(`[saveContractEvent] (tx ${event.tx.hash}): failed to save contract
+(storeCodeMsg): ${JSON.stringify(storeCodeMsg, null, 2)},
+(instantiateMsg): ${JSON.stringify(instantiateMsg, null, 2)})`);
     return;
   }
 


### PR DESCRIPTION
## Changes

- improve formatting of `saveContractEvent` warning
  - use `JSON.stringify` to prevent logging the string literal `[object Object]`
  - add line breaks to ease readability (log output is multiple lines)

![image](https://user-images.githubusercontent.com/600733/199191398-1c0d8cf4-b2c3-4c2e-8245-235c9514ca40.png)
