### PR TITLE
feat: add contract relation to legacy bridge swap

### DIFF
--- a/migrations/committed/000005.sql
+++ b/migrations/committed/000005.sql
@@ -1,0 +1,12 @@
+--! Previous: sha1:da26eb35d28f84418481866c2f08a576617e9bc6
+--! Hash: sha1:b16de8bb2e28541b6b0444a5fb2ecc79874e5cec
+
+-- Enter migration here
+CREATE SCHEMA IF NOT EXISTS app;
+SET SCHEMA 'app';
+
+alter table app.legacy_bridge_swaps
+    RENAME column contract to contract_id;
+CREATE INDEX legacy_bridge_swaps_contract_id ON app.legacy_bridge_swaps USING hash (contract_id);
+ALTER TABLE ONLY app.legacy_bridge_swaps
+    ADD CONSTRAINT legacy_bridge_swaps_contract_id_fkey FOREIGN KEY (contract_id) REFERENCES app.contracts(id) ON UPDATE CASCADE;

--- a/migrations/committed/000005.sql
+++ b/migrations/committed/000005.sql
@@ -7,6 +7,5 @@ SET SCHEMA 'app';
 
 alter table app.legacy_bridge_swaps
     RENAME column contract to contract_id;
-CREATE INDEX legacy_bridge_swaps_contract_id ON app.legacy_bridge_swaps USING hash (contract_id);
 ALTER TABLE ONLY app.legacy_bridge_swaps
     ADD CONSTRAINT legacy_bridge_swaps_contract_id_fkey FOREIGN KEY (contract_id) REFERENCES app.contracts(id) ON UPDATE CASCADE;

--- a/migrations/committed/000005.sql
+++ b/migrations/committed/000005.sql
@@ -7,5 +7,6 @@ SET SCHEMA 'app';
 
 alter table app.legacy_bridge_swaps
     RENAME column contract to contract_id;
+CREATE INDEX legacy_bridge_swaps_contract_id ON app.legacy_bridge_swaps USING hash (contract_id);
 ALTER TABLE ONLY app.legacy_bridge_swaps
     ADD CONSTRAINT legacy_bridge_swaps_contract_id_fkey FOREIGN KEY (contract_id) REFERENCES app.contracts(id) ON UPDATE CASCADE;

--- a/schema.graphql
+++ b/schema.graphql
@@ -106,7 +106,7 @@ type Contract @entity {
 type LegacyBridgeSwap @entity {
   id: ID! # id field is always required and must look like this
   destination: String!
-  contract: Contract! @index
+  contract: Contract!
   amount: BigInt!
   denom: String!
   executeContractMessage: ExecuteContractMessage!

--- a/schema.graphql
+++ b/schema.graphql
@@ -106,7 +106,7 @@ type Contract @entity {
 type LegacyBridgeSwap @entity {
   id: ID! # id field is always required and must look like this
   destination: String!
-  contract: String!
+  contract: Contract! @index
   amount: BigInt!
   denom: String!
   executeContractMessage: ExecuteContractMessage!

--- a/src/genesis/helpers/field_enums.py
+++ b/src/genesis/helpers/field_enums.py
@@ -195,7 +195,7 @@ class LegacyBridgeSwapFields(NamedFields):
     destination = 4
     amount = 5
     denom = 6
-    contract = 7
+    contract_id = 7
 
     @classmethod
     @property

--- a/src/mappings/wasm/bridge.ts
+++ b/src/mappings/wasm/bridge.ts
@@ -13,7 +13,7 @@ async function _handleLegacyBridgeSwap(event: CosmosEvent): Promise<void> {
   logger.info(`[handleLegacyBridgeSwap] (tx ${msg.tx.hash}): indexing LegacyBridgeSwap ${id}`);
   logger.debug(`[handleLegacyBridgeSwap] (event.msg.msg): ${JSON.stringify(msg.msg, null, 2)}`);
 
-  const contract = msg?.msg?.decodedMsg?.contract;
+  const contractId = msg?.msg?.decodedMsg?.contract;
   const swapMsg = msg?.msg?.decodedMsg?.msg;
   const destination = swapMsg?.swap?.destination;
 
@@ -23,7 +23,7 @@ async function _handleLegacyBridgeSwap(event: CosmosEvent): Promise<void> {
 
   // gracefully skip indexing "swap" messages that doesn't fullfill the bridge contract
   // otherwise, the node will just crashloop trying to save the message to the db with required null fields.
-  if (!destination || !amount || !denom || !contract) {
+  if (!destination || !amount || !denom || !contractId) {
     logger.warn(`[handleLegacyBridgeSwap] (tx ${msg.tx.hash}): cannot index message (event.msg.msg): ${JSON.stringify(msg.msg, null, 2)}`);
     return;
   }
@@ -31,7 +31,7 @@ async function _handleLegacyBridgeSwap(event: CosmosEvent): Promise<void> {
   const legacySwap = LegacyBridgeSwap.create({
     id,
     destination,
-    contract,
+    contractId,
     amount: BigInt(amount),
     denom,
     executeContractMessageId: id,

--- a/tests/e2e/entities/test_execute_contract_message.py
+++ b/tests/e2e/entities/test_execute_contract_message.py
@@ -30,6 +30,9 @@ class TestContractExecution(EntityTest):
         cls._contract = BridgeContract(
             cls.ledger_client, cls.validator_wallet, DefaultBridgeContractConfig
         )
+        code_id = cls._contract._store()
+        cls._contract._instantiate(code_id)
+
         for i in range(3):  # enough entities are created to verify sorting
             resp = cls._contract.execute(
                 {cls.method: {"destination": cls.validator_address}},
@@ -37,9 +40,8 @@ class TestContractExecution(EntityTest):
                 funds=str(cls.amount) + cls.denom,
             )
             cls.ledger_client.wait_for_query_tx(resp.tx_hash)
-        time.sleep(
-            5
-        )  # stil need to give some extra time for the indexer to pickup the tx
+        # stil need to give some extra time for the indexer to pickup the tx
+        time.sleep(5)
 
     def test_contract_execution(self):
         execMsgs = self.db_cursor.execute(


### PR DESCRIPTION
- **Wait for #210 to be merged** 
  - Migration order needs to be updated, as that PR also features migration number 5. 

- Amends `legacy_bridge_swap` entity to include relation to relevant `contract` entity.
  - changes `contract` field to include this relation, instead of storing contract address only.
- Refactors bridge contract deployment to allow for multiple instances, for test repeatability.

**Addressing** #200 


## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Either the PR references an issue (via the "Development" combobox) or the description explains the need for the changes.
- [ ] The PR appropriately sized.
- [ ] The PR contains an idempotent DB migration.
- [ ] I have verified the correctness of the DB migration using relevant data (e.g. test-generated data).
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
