### PR TITLE
fix: package.json remove duplicate script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test": "jest",
     "codegen": "subql codegen",
     "start:docker": "docker-compose pull && docker-compose up --remove-orphans",
-    "start:docker": "docker-compose pull && docker-compose up --remove-orphans",
     "start:tracing": "docker-compose -f docker-compose.tracing.yml pull && docker-compose -f docker-compose.tracing.yml up --remove-orphans",
     "stop:tracing": "docker-compose -f docker-compose.tracing.yml down",
     "db:dump": "pg_dump --schema app -c --if-exists --file migrations/current_schema.sql postgres://subquery:subquery@localhost/subquery",


### PR DESCRIPTION
## Background

I've noticed some warnings recently about this duplicate.

## Changes

- remove duplicate package script (`start:docker`)

---

## Code Review Checklist (to be filled out by reviewer)

- [x] Description accurately reflects what changes are being made.
- [x] Either the PR references an issue (via the "Development" combobox) or the description explains the need for the changes.
- [x] The PR appropriately sized.
- [ ] The PR contains an idempotent DB migration.
- [ ] I have verified the correctness of the DB migration using relevant data (e.g. test-generated data).
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
