### PR TITLE
fix: set WARNING level on gql aiohttp transport logger

### DIFF
--- a/tests/helpers/clients.py
+++ b/tests/helpers/clients.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import unittest
 from pathlib import Path
@@ -7,6 +8,7 @@ import dateutil.parser as dp
 import psycopg
 from gql import Client
 from gql.transport.aiohttp import AIOHTTPTransport
+from gql.transport.aiohttp import log as aiohttp_logger
 from psycopg import Connection, Cursor
 
 from src.genesis.db import table_exists
@@ -16,6 +18,8 @@ from .gql_queries import latest_block_timestamp
 repo_root_path = Path(__file__).parent.parent.parent.parent.absolute()
 sys.path.append(repo_root_path)
 
+
+aiohttp_logger.setLevel(logging.WARNING)
 
 CASCADE_TRUNCATE_TABLES = frozenset({"blocks", "transactions", "messages", "events"})
 


### PR DESCRIPTION
## Background

Recently, I presume due to a pipfile update or something, the logger contained in the graphql client package we're using in our end-to-end tests has become unusably verbose by default; see [gql docs -> logging -> disabling logs](https://gql.readthedocs.io/en/latest/advanced/logging.html#disabling-logs).

## Changes

- Set log level to WARNING insetad of INFO for gql client / aiohttp transport

## Effect

See #187 CI output:
- [Before](https://github.com/fetchai/ledger-subquery/actions/runs/3686304284/jobs/6238350465) - (fd1f8f7)
- [After](https://github.com/fetchai/ledger-subquery/actions/runs/3695154429/jobs/6257190485) - (af85236)

---

## Code Review Checklist (to be filled out by reviewer)

- [x] Description accurately reflects what changes are being made.
- [x] Either the PR references an issue (via the "Development" combobox) or the description explains the need for the changes.
- [x] The PR appropriately sized.
- [ ] The PR contains an idempotent DB migration.
- [ ] I have verified the correctness of the DB migration using relevant data (e.g. test-generated data).
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
