### PR TITLE
feat: add tuning handler

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -137,3 +137,10 @@ dataSources:
             messageFilter:
               type: "/cosmwasm.wasm.v1.MsgExecuteContract"
               contractCall: "register"
+        - handler: handleTuningContractExecute
+          kind: cosmos/EventHandler
+          filter:
+            type: "execute"
+            messageFilter:
+              type: "/cosmwasm.wasm.v1.MsgExecuteContract"
+              contractCall: "tuning"

--- a/schema.graphql
+++ b/schema.graphql
@@ -148,6 +148,7 @@ type Account @entity {
   chainId: String! @index
   nativeBalanceChanges: [NativeBalanceChange]! @derivedFrom(field: "account")
   cw20BalanceChanges: [Cw20BalanceChange]! @derivedFrom(field: "account")
+  tuningData: [Cw20BalanceChange]! @derivedFrom(field: "account")
   genesisBalances: [GenesisBalance] @derivedFrom(field: "account")
 }
 
@@ -238,6 +239,18 @@ type IbcTransfer @entity {
 }
 
 type Cw20BalanceChange @entity {
+  id: ID!
+  balanceOffset: BigInt!
+  contract: Contract!
+  account: Account!
+  executeContractMessage: ExecuteContractMessage!
+  event: Event!
+  message: Message!
+  transaction: Transaction!
+  block: Block!
+}
+
+type TuningData @entity {
   id: ID!
   balanceOffset: BigInt!
   contract: Contract!

--- a/src/mappings/wasm/tuning.ts
+++ b/src/mappings/wasm/tuning.ts
@@ -1,0 +1,42 @@
+import {CosmosEvent} from "@subql/types-cosmos";
+import {Cw20BalanceChange, Cw20Transfer, TuningData} from "../../types";
+import {
+  attemptHandling,
+  checkBalancesAccount,
+  unprocessedEventHandler,
+  messageId,
+} from "../utils";
+
+export async function handleTuningContractExecute(event: CosmosEvent): Promise<void> {
+  await attemptHandling(event, _handleTuningContractExecute, unprocessedEventHandler);
+}
+
+async function _handleTuningContractExecute(event: CosmosEvent): Promise<void> {
+  logger.fatal("HERE : INSIDE _handleTuningContract")
+  const id = messageId(event.msg);
+  logger.info(`[handleTuningExecute] (tx ${event.tx.hash}): indexing TuningExecute ${id}`);
+  logger.debug(`[handleTuningExecute] (event.msg.msg): ${JSON.stringify(event.msg.msg, null, 2)}`);
+
+  const msg = event.msg?.msg?.decodedMsg;
+  const contractId = msg?.contract;
+
+
+  if (!contractId) {
+    logger.warn(`[handleTuningExecute] (tx ${event.tx.hash}): cannot index event (event.event): ${JSON.stringify(event.event, null, 2)}`);
+    return;
+  }
+
+  const TuningDataEntity = TuningData.create({
+    id,
+    balanceOffset: BigInt(1),
+    contractId,
+    accountId: "sample",
+    executeContractMessageId: msg,
+    eventId: "sample",
+    messageId: id,
+    transactionId: event.tx.hash,
+    blockId: event.block.block.id
+  });
+
+  await TuningDataEntity.save();
+}


### PR DESCRIPTION
## Changes

In the PR have tried to add a new handler for catching `Tuning` contract events separately and store them in database.
Complete feature require to capture 2 events, `Initiate` & `Execute`.

This PR only contains the changes to handle `Execute` event and is still under testing.

[JIRA](https://fetchai.atlassian.net/browse/ATX-1656) for this PR.

## Completed?
- [ ] Yes
- [x] No

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Either the PR references an issue (via the "Development" combobox) or the description explains the need for the changes.
- [ ] The PR appropriately sized.
- [ ] The PR contains an idempotent DB migration.
- [ ] I have verified the correctness of the DB migration using relevant data (e.g. test-generated data).
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.