### PR TITLE
fix: allow indexing of failed transactions

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -33,6 +33,8 @@ dataSources:
           kind: cosmos/BlockHandler
         - handler: handleTransaction
           kind: cosmos/TransactionHandler
+          filter:
+            includeFailedTx: true
         - handler: handleMessage
           kind: cosmos/MessageHandler
         - handler: handleEvent


### PR DESCRIPTION
Implements the `includeFailedTx` flag in the project manifest file
- Allows failed transactions to be indexed

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Either the PR references an issue (via the "Development" combobox) or the description explains the need for the changes.
- [ ] The PR appropriately sized.
- [ ] The PR contains an idempotent DB migration.
- [ ] I have verified the correctness of the DB migration using relevant data (e.g. test-generated data).
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
