### PR TITLE
fix: removed prohibitive over-filtering of contract messages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,23 @@
 version: "3"
 
 services:
+  genesis-processor:
+    build:
+      context: .
+      dockerfile: ./docker/genesis.dockerfile
+    environment:
+      DB_USER: "subquery"
+      DB_PASS: "subquery"
+      DB_DATABASE: "subquery"
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_SCHEMA: app
+      JSON_URL: https://storage.googleapis.com/fetch-ai-testnet-genesis/genesis-dorado-827201.json
+      NETWORK: dorado
+    depends_on:
+      "subquery-node":
+          condition: service_started
+
   postgres:
     build:
       context: .

--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -21,12 +21,10 @@ services:
     build:
       context: .
       dockerfile: ./docker/node.dockerfile
+    restart: always
     depends_on:
       "postgres":
         condition: service_healthy
-      "fetch-node":
-        condition: service_started
-    restart: always
     environment:
       DB_USER: "subquery"
       DB_PASS: "subquery"

--- a/project.yaml
+++ b/project.yaml
@@ -29,6 +29,7 @@ dataSources:
     mapping:
       file: "./dist/index.js"
       handlers:
+# -------- Primitives
         - handler: handleBlock
           kind: cosmos/BlockHandler
         - handler: handleTransaction
@@ -39,50 +40,35 @@ dataSources:
           kind: cosmos/MessageHandler
         - handler: handleEvent
           kind: cosmos/EventHandler
+# -------- Governance
         - handler: handleGovProposalVote
           kind: cosmos/EventHandler
           filter:
             type: "proposal_vote"
             messageFilter:
               type: "/cosmos.gov.v1beta1.MsgVote"
+# -------- Staking
         - handler: handleDistDelegatorClaim
           kind: cosmos/EventHandler
           filter:
             type: "withdraw_rewards"
             messageFilter:
               type: "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
-        - handler: handleExecuteContractEvent
+        - handler: handleDelegatorWithdrawRewardEvent
           kind: cosmos/EventHandler
           filter:
-            type: "execute"
-            messageFilter:
-              type: "/cosmwasm.wasm.v1.MsgExecuteContract"
-        - handler: handleLegacyBridgeSwap
-          kind: cosmos/EventHandler
+            type: "withdraw_rewards"
+        - handler: handleAuthzExec
+          kind: cosmos/MessageHandler
           filter:
-            type: "execute"
-            messageFilter:
-              type: "/cosmwasm.wasm.v1.MsgExecuteContract"
-              # Filter to only messages with the swap function call
-              contractCall: "swap"
+            type: "/cosmos.authz.v1beta1.MsgExec"
+# -------- Bank
         - handler: handleNativeTransfer
           kind: cosmos/EventHandler
           filter:
             type: "transfer"
             messageFilter:
               type: "/cosmos.bank.v1beta1.MsgSend"
-        - handler: handleDelegatorWithdrawRewardEvent
-          kind: cosmos/EventHandler
-          filter:
-            type: "withdraw_rewards"
-        # TODO: perhaps merge this handler config and that of Cw20BalanceTransfer
-        - handler: handleCw20Transfer
-          kind: cosmos/EventHandler
-          filter:
-            type: "execute"
-            messageFilter:
-              type: "/cosmwasm.wasm.v1.MsgExecuteContract"
-              contractCall: "transfer"
         - handler: handleNativeBalanceDecrement
           kind: cosmos/EventHandler
           filter:
@@ -91,6 +77,35 @@ dataSources:
           kind: cosmos/EventHandler
           filter:
             type: "coin_received"
+# -------- Wasm
+        - handler: handleContractStoreEvent
+          kind: cosmos/EventHandler
+          filter:
+            type: "store_code"
+        - handler: handleContractInstantiateEvent
+          kind: cosmos/EventHandler
+          filter:
+            type: "instantiate"
+        - handler: handleExecuteContractEvent
+          kind: cosmos/EventHandler
+          filter:
+            type: "execute"
+        - handler: handleLegacyBridgeSwap
+          kind: cosmos/EventHandler
+          filter:
+            type: "execute"
+            messageFilter:
+              type: "/cosmwasm.wasm.v1.MsgExecuteContract"
+              # Filter to only messages with the swap function call
+              contractCall: "swap"
+        # TODO: perhaps merge this handler config and that of Cw20BalanceTransfer
+        - handler: handleCw20Transfer
+          kind: cosmos/EventHandler
+          filter:
+            type: "execute"
+            messageFilter:
+              type: "/cosmwasm.wasm.v1.MsgExecuteContract"
+              contractCall: "transfer"
         - handler: handleIBCTransfer
           kind: cosmos/EventHandler
           filter:
@@ -116,22 +131,7 @@ dataSources:
             messageFilter:
               type: "/cosmwasm.wasm.v1.MsgExecuteContract"
               contractCall: "mint"
-        - handler: handleContractStoreEvent
-          kind: cosmos/EventHandler
-          filter:
-            type: "store_code"
-            messageFilter:
-              type: "/cosmwasm.wasm.v1.MsgStoreCode"
-        - handler: handleContractInstantiateEvent
-          kind: cosmos/EventHandler
-          filter:
-            type: "instantiate"
-            messageFilter:
-              type: "/cosmwasm.wasm.v1.MsgInstantiateContract"
-        - handler: handleAuthzExec
-          kind: cosmos/MessageHandler
-          filter:
-            type: "/cosmos.authz.v1beta1.MsgExec"
+# -------- Agents
         - handler: handleAlmanacRegistration
           kind: cosmos/EventHandler
           filter:

--- a/schema.graphql
+++ b/schema.graphql
@@ -302,9 +302,9 @@ type StoreContractMessage @entity {
 type InstantiateContractMessage @entity {
   id: ID!
   sender: String! @index
-  admin: String!
+  admin: String
   codeId: Int!
-  label: String!
+  label: String
   payload: String!
   funds: [Coin]
   timeline: BigInt! @index

--- a/src/mappings/wasm/contracts.ts
+++ b/src/mappings/wasm/contracts.ts
@@ -33,8 +33,6 @@ export async function handleContractInstantiateEvent(event: CosmosEvent): Promis
 }
 
 async function _handleExecuteContractEvent(event: CosmosEvent): Promise<void> {
-  // logger.fatal(`${JSON.stringify(event.event.type, null, 2)}\n\n${JSON.stringify(event.event.attributes, null, 2)}\n\n`);
-  logger.fatal(`\n\n${JSON.stringify(event.msg.msg.decodedMsg, null, 2)}\n\n`);
   const msg: CosmosMessage<ExecuteContractMsg> = event.msg;
   logger.info(`[handleExecuteContractMessage] (tx ${msg.tx.hash}): indexing ExecuteContractMessage ${messageId(msg)}`);
   logger.debug(`[handleExecuteContractMessage] (event.msg.msg): ${JSON.stringify(msg.msg, null, 2)}`);
@@ -114,7 +112,7 @@ async function _handleContractInstantiateEvent(event: CosmosEvent): Promise<void
     const id = `${messageId(event.msg)}-${i}`;
     const contract_address = Object.entries(contract_addresses)[i][1].value;
 
-    if (!sender || !label || !payload || !codeId || !contract_address) {
+    if (!sender || !payload || !codeId || !contract_address) {
       logger.warn(`[handleContractInstantiateEvent] (tx ${event.tx.hash}): cannot index event (event.event): ${JSON.stringify(event.event, null, 2)}`);
       return;
     }
@@ -141,9 +139,7 @@ async function saveContractEvent(instantiateMsg: InstantiateContractMessage, con
   const storeCodeMsg = (await StoreContractMessage.getByCodeId(instantiateMsg.codeId))[0];
 
   if (!storeCodeMsg || !contract_address || !instantiateMsg) {
-    logger.warn(`[saveContractEvent] (tx ${event.tx.hash}): failed to save contract
-(storeCodeMsg): ${JSON.stringify(storeCodeMsg, null, 2)},
-(instantiateMsg): ${JSON.stringify(instantiateMsg, null, 2)})`);
+    logger.warn(`[saveContractEvent] (tx ${event.tx.hash}): failed to save contract (storeCodeMsg): ${(storeCodeMsg?.id)}, (instantiateMsg): ${(instantiateMsg?.id)})`);
     return;
   }
 


### PR DESCRIPTION
- Nested contract-contract calls, e.g. an Execution message on one contract calling the instantiation of another, being obstructed by over-filtering of handler triggers.
  - In this example, the instantiation message would not be indexed, as it was called as part of an Execution message. With the previous heavy-handed message filtering, all instantiation calls required the event of type `instantiation` as well as the message `typeUrl `to be that of an instantiation.
- Schema changed to reflect `instantiateMsg` optional properties, `admin` & `label`.
- Removed leftover prints
- Refactored handler config into module categories
- Added genesis processor config to testing `docker-compose.yml`
---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Either the PR references an issue (via the "Development" combobox) or the description explains the need for the changes.
- [ ] The PR appropriately sized.
- [ ] The PR contains an idempotent DB migration.
- [ ] I have verified the correctness of the DB migration using relevant data (e.g. test-generated data).
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
