### PR TITLE
fix: allow re-instantiation of genesis contracts

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -106,7 +106,7 @@ type Contract @entity {
   interface: Interface!
   storeMessage: StoreContractMessage
   instantiateMessage: InstantiateContractMessage
-  codeId: Int!
+  codeId: Int! @index
 }
 
 type LegacyBridgeSwap @entity {

--- a/src/mappings/wasm/contracts.ts
+++ b/src/mappings/wasm/contracts.ts
@@ -138,7 +138,8 @@ async function _handleContractInstantiateEvent(event: CosmosEvent): Promise<void
 async function saveContractEvent(instantiateMsg: InstantiateContractMessage, contract_address: string, event: CosmosEvent) {
   const storeCodeMsg = (await StoreContractMessage.getByCodeId(instantiateMsg.codeId))[0];
 
-  if (!storeCodeMsg || !contract_address || !instantiateMsg) {
+  // Allow contracts to be created without a storeMsg, incase they are a re-instantiation of a genesis contract
+  if (!contract_address || !instantiateMsg) {
     logger.warn(`[saveContractEvent] (tx ${event.tx.hash}): failed to save contract (storeCodeMsg): ${(storeCodeMsg?.id)}, (instantiateMsg): ${(instantiateMsg?.id)})`);
     return;
   }


### PR DESCRIPTION
Fixes indexer halting when re-instantiating genesis contracts without indexed `store_code` messages.
- removes halting requirement for a relevant `store_code` msg entity.

---

## Code Review Checklist (to be filled out by reviewer)

- [ ] Description accurately reflects what changes are being made.
- [ ] Either the PR references an issue (via the "Development" combobox) or the description explains the need for the changes.
- [ ] The PR appropriately sized.
- [ ] The PR contains an idempotent DB migration.
- [ ] I have verified the correctness of the DB migration using relevant data (e.g. test-generated data).
- [ ] New code has enough tests.
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
